### PR TITLE
v1.3.1 重新整理多方案下, 定时启动和编辑方案的逻辑. 启动后将锁定配置, 不应用实时更新.

### DIFF
--- a/function/core/FAA.py
+++ b/function/core/FAA.py
@@ -1744,11 +1744,8 @@ class FAA:
 
 if __name__ == '__main__':
     def f_main():
-        faa = FAA(channel="锑食")
-        faa.set_config_for_battle(
-            stage_id="NO-1-14",
-            is_group=False,
-            battle_plan_index=0)
+        faa = FAA(channel="锑食-微端")
+        faa.delete_items()
 
 
     f_main()

--- a/function/core/QMW_1_load_settings.py
+++ b/function/core/QMW_1_load_settings.py
@@ -23,7 +23,7 @@ class QMainWindowLoadSettings(QMainWindowLoadUI):
         # 从json文件中读取opt 并刷新ui
         self.opt = None
         self.json_to_opt()
-        self.opt_to_ui()
+        self.init_opt_to_ui()
 
     def json_to_opt(self):
         with open(self.opt_path) as json_file:
@@ -43,8 +43,10 @@ class QMainWindowLoadSettings(QMainWindowLoadUI):
         先从ui上读取目前todo plan index, 然后从opt读取对应的设置到todo plan 配置界面
         :return:
         """
-        # 先重新获取ui上的 选项
+        # 先重新获取ui上的 当前方案选项
         self.opt["current_plan"] = self.CurrentPlan.currentIndex()  # combobox 序号
+        # 修改当前方案文本
+        self.CurrentPlan_Label_Change.setText(self.CurrentPlan.currentText())
 
         battle_plan_list = get_list_battle_plan(with_extension=False)
         customize_todo_list = get_customize_todo_list(with_extension=False)
@@ -229,7 +231,7 @@ class QMainWindowLoadSettings(QMainWindowLoadUI):
         self.AutoFood_Active.setChecked(my_opt["auto_food"]["active"])
         self.AutoFood_Deck.setValue(my_opt["auto_food"]["deck"])
 
-    def opt_to_ui(self):
+    def init_opt_to_ui(self):
         # comboBox.setCurrentIndex时 如果超过了已有预设 会显示为空 不会报错
         # comboBox.clear时 会把所有选项设定为默认选项
 
@@ -554,7 +556,7 @@ class QMainWindowLoadSettings(QMainWindowLoadUI):
             return
         del self.opt["todo_plans"][self.CurrentPlan.currentIndex()]
         # 重载ui
-        self.opt_to_ui()
+        self.init_opt_to_ui()
 
     def rename_current_plan(self):
         """用来重命名当前被选中的 todo plan 但不能重命名默认方案"""
@@ -563,7 +565,7 @@ class QMainWindowLoadSettings(QMainWindowLoadUI):
             return
         self.opt["todo_plans"][self.CurrentPlan.currentIndex()]["name"] = copy.deepcopy(self.RenamePlan_Input.text())
         # 重载ui
-        self.opt_to_ui()
+        self.init_opt_to_ui()
 
     def create_new_plan(self):
         """新建一个 todo plan, 但不能取名为Default"""
@@ -574,13 +576,7 @@ class QMainWindowLoadSettings(QMainWindowLoadUI):
         self.opt["todo_plans"].append(copy.deepcopy(self.opt["todo_plans"][0]))
         self.opt["todo_plans"][-1]["name"] = copy.deepcopy(self.CreatePlan_Input.text())
         # 重载ui
-        self.opt_to_ui()
-
-    # def click_btn_advanced_settings(self):
-    #     # 高级设置的槽函数
-    #     self.AdvancedSettings = AdvancedSettingsWindow()
-    #     # 显示临时窗口
-    #     self.AdvancedSettings.show()
+        self.init_opt_to_ui()
 
 
 if __name__ == "__main__":

--- a/function/core/Todo.py
+++ b/function/core/Todo.py
@@ -22,7 +22,7 @@ class ThreadTodo(QThread):
     signal_start_todo_2_battle = pyqtSignal(dict)
     signal_todo_lock = pyqtSignal(bool)
 
-    def __init__(self, faa, opt, signal_dict, todo_id):
+    def __init__(self, faa, opt, running_todo_plan_index, signal_dict, todo_id):
         super().__init__()
 
         # 用于暂停恢复
@@ -1274,7 +1274,7 @@ class ThreadTodo(QThread):
 
     def alone_magic_tower(self):
 
-        c_opt = self.opt["todo_plans"][self.opt["current_plan"]]
+        c_opt = self.opt_todo_plans
 
         def one_player():
             for player in [1, 2]:
@@ -1348,7 +1348,7 @@ class ThreadTodo(QThread):
 
     def alone_magic_tower_prison(self):
 
-        c_opt = self.opt["todo_plans"][self.opt["current_plan"]]
+        c_opt = self.opt_todo_plans
 
         def one_player():
             for player in [1, 2]:
@@ -1439,7 +1439,7 @@ class ThreadTodo(QThread):
 
     def pet_temple(self):
 
-        c_opt = self.opt["todo_plans"][self.opt["current_plan"]]
+        c_opt = self.opt_todo_plans
 
         def one_player():
             for player in [1, 2]:
@@ -1527,7 +1527,7 @@ class ThreadTodo(QThread):
     def run_1(self):
 
         # current todo plan option
-        c_opt = self.opt["todo_plans"][self.opt["current_plan"]]
+        c_opt = self.opt_todo_plans
 
         start_time = datetime.datetime.now()
 

--- a/function/scattered/TodoTimerManager.py
+++ b/function/scattered/TodoTimerManager.py
@@ -6,11 +6,10 @@ from function.globals.log import CUS_LOGGER
 
 
 class TodoTimerManager:
-    def __init__(self, opt, function_change_current_todo_plan, function_thread_todo_start):
+    def __init__(self, opt, func_thread_todo_start):
         self.todo_timers = {}
 
-        self.change_current_todo_plan = function_change_current_todo_plan
-        self.thread_todo_start = function_thread_todo_start
+        self.thread_todo_start = func_thread_todo_start
 
         self.opt = copy.deepcopy(opt)  # 深拷贝 意味着开始运行后再配置不会有反应
 
@@ -51,10 +50,8 @@ class TodoTimerManager:
         self.todo_timers[timer_index] = timer
 
     def call_back(self, timer_index, plan_index, tar_time):
-        # 修改当前计划
-        self.change_current_todo_plan.emit(plan_index)
         # 启动线程
-        self.thread_todo_start.emit()
+        self.thread_todo_start.emit(plan_index)
         # 动态校准时间
         delta_seconds = 0
         while delta_seconds < 60:


### PR DESCRIPTION
重新整理了多方案情况下, 定时启动和编辑方案的逻辑.
已完成了正在编辑的方案和正在运行的方案的分离: 开始运行后, 将以启动时的方案的拷贝为准, 以进行各项自动化流程的进行, 编辑不会影响正在运行中的流程, 需要重新开始以进行应用. 增加了正在运行的方案和正在编辑的方案的ui文本/运行输出/提示信息, 以向用户反映这种变化.