### PR TITLE
v1.4.0-beta.4 自动战斗 - 自动承载/任务卡. 其插入位置不再是首位, 而是第二位, 解决部分无风化玩家的开局产火问题. 

### DIFF
--- a/function/core/FAA.py
+++ b/function/core/FAA.py
@@ -471,8 +471,8 @@ class FAA:
                     "location_to": []
                 }
 
-                # 首位插入
-                list_cell_all.insert(0, dict_quest)
+                # 第二位插入
+                list_cell_all.insert(1, dict_quest)
                 return list_cell_all
 
         def calculation_card_ban(list_cell_all):
@@ -519,7 +519,7 @@ class FAA:
                     "location_from": mat_card_position[i]["location_from"],
                     "location_to": []}
                 # 首位插入
-                list_cell_all.insert(0, dict_mat)
+                list_cell_all.insert(1, dict_mat)
 
             return list_cell_all
 


### PR DESCRIPTION
因为承载和任务卡优先级超过了产火卡. 
这会导致风化+0能耗承载的玩家晚7s开始放置承载卡 orz,
但考虑到对于地产玩家问题更严重, 故进行该修改.