### PR TITLE
v1.4.0-beta.4 战斗执行器 - 使用钥匙. 完成了该被遗漏的功能.

### DIFF
--- a/function/core/FAA.py
+++ b/function/core/FAA.py
@@ -67,7 +67,7 @@ class FAA:
         self.stage_info = None
         self.is_main = None
         self.is_group = None
-        self.is_use_key = None
+        self.need_key = None
         self.deck = None
         self.quest_card = None
         self.ban_card_list = None
@@ -206,13 +206,13 @@ class FAA:
     """调用输入关卡配置和战斗配置, 在战斗前必须进行该操作"""
 
     def set_config_for_battle(
-            self, stage_id="NO-1-1", is_group=False, is_main=True, is_use_key=True,
+            self, stage_id="NO-1-1", is_group=False, is_main=True, need_key=True,
             deck=1, quest_card="None", ban_card_list=None,
             battle_plan_index=0) -> None:
         """
         :param is_group: 是否组队
         :param is_main: 是否是主要账号(单人为True 双人房主为True)
-        :param is_use_key: 是否使用钥匙
+        :param need_key: 是否使用钥匙
         :param deck:
         :param quest_card:
         :param ban_card_list:
@@ -226,7 +226,7 @@ class FAA:
 
         self.is_main = is_main
         self.is_group = is_group
-        self.is_use_key = is_use_key
+        self.need_key = need_key
         self.deck = deck
         self.quest_card = quest_card
         self.ban_card_list = ban_card_list
@@ -845,7 +845,7 @@ class FAA:
                             {
                                 "stage_id": battle_sets[0],
                                 "player": [self.player] if battle_sets[1] == "1" else [2, 1],  # 1 单人 2 组队
-                                "is_use_key": bool(battle_sets[2]),  # 注意类型转化
+                                "need_key": bool(battle_sets[2]),  # 注意类型转化
                                 "max_times": 1,
                                 "quest_card": battle_sets[3],
                                 "ban_card_list": ban_card_list,

--- a/function/core/FAA_Battle.py
+++ b/function/core/FAA_Battle.py
@@ -88,6 +88,10 @@ class Battle:
         :return:
             None
         """
+        # 如果不需要使用钥匙 或者 已经用过钥匙 直接输出
+        if not self.faa.need_key or self.is_used_key:
+            return False
+
         find = match_p_in_w(
             source_handle=self.faa.handle,
             source_range=[386, 332, 463, 362],

--- a/function/core/Todo.py
+++ b/function/core/Todo.py
@@ -850,12 +850,14 @@ class ThreadTodo(QThread):
                 result_id, result_loot, result_spend_time = self.battle(player_a=player_a, player_b=player_b)
 
                 if result_id == 0:
+
                     # 战斗成功 计数+1
                     battle_count += 1
-                    # 计数战斗是否使用了钥匙
-                    this_time_of_battle_is_used_key = faa_a.faa_battle.is_used_key
-                    if is_group:
-                        this_time_of_battle_is_used_key = this_time_of_battle_is_used_key or faa_b.faa_battle.is_used_key
+
+                    # 计数战斗是否使用了钥匙, 由于一个号用过后两个号都会被修改为用过, 故不需要多余的判断
+                    # this_battle_is_used_key = faa_a.faa_battle.is_used_key
+                    # if is_group:
+                    #     this_battle_is_used_key = this_battle_is_used_key or faa_b.faa_battle.is_used_key
 
                     if battle_count < max_times:
                         # 常规退出方式
@@ -872,10 +874,13 @@ class ThreadTodo(QThread):
                             for j in dict_exit["last_time_player_b"]:
                                 faa_b.action_exit(mode=j)
 
+                    # 获取是否使用了钥匙 仅查看房主(任意一个号用了钥匙都会更改为两个号都用了)
+                    is_used_key = faa_a.faa_battle.is_used_key
+
                     # 加入结果统计列表
                     result_list.append({
                         "time_spend": result_spend_time,
-                        "is_used_key": this_time_of_battle_is_used_key,
+                        "is_used_key": is_used_key,
                         "loot_dict_list": result_loot  # result_loot_dict_list = [{a掉落}, {b掉落}]
                     })
 
@@ -884,7 +889,7 @@ class ThreadTodo(QThread):
                         text="{}第{}次, {}, 正常结束, 耗时:{}分{}秒".format(
                             title,
                             battle_count,
-                            "使用钥匙" if this_time_of_battle_is_used_key else "未使用钥匙",
+                            "使用钥匙" if is_used_key else "未使用钥匙",
                             *divmod(int(result_spend_time), 60)
                         )
                     )

--- a/function/core_battle/CardManager.py
+++ b/function/core_battle/CardManager.py
@@ -193,7 +193,7 @@ class ThreadCheckTimer(QThread):
                 self.stopped = True  # 防止stop后再次调用
             return
 
-        # 看看是不是需要使用钥匙 如果使用成功 发送信号 修改faa.battle中的相关参数为True 以标识
+        # 尝试使用钥匙 如成功 发送信号 修改faa.battle中的is_used_key为True 以标识用过了, 如果不需要使用或用过了, 会直接False
         if self.faa.faa_battle.use_key():
             self.used_key_signal.emit()
 


### PR DESCRIPTION
一个古老的问题, 遗漏了是否使用钥匙参数, 导致无论如何设置, 都会使用钥匙. 
修复了该问题, 仅在需要使用钥匙时判断识图点击钥匙, 且当钥匙被使用后, 本场作战中不再尝试识图钥匙节省开销.