### PR TITLE
v1.4.0-beta.10 修复双人魔塔和萌宠神殿交换顺序后, 萌宠神殿完成后不退出, 需触发防卡死才能正常继续的问题.

### DIFF
--- a/function/core/Todo.py
+++ b/function/core/Todo.py
@@ -1658,8 +1658,8 @@ class ThreadTodo(QThread):
                         dict_exit={
                             "other_time_player_a": [],
                             "other_time_player_b": [],
-                            "last_time_player_a": [],  # "回到上一级","普通红叉" 但之后刷新 所以空
-                            "last_time_player_b": []
+                            "last_time_player_a": ["回到上一级","普通红叉"],
+                            "last_time_player_b": ["回到上一级","普通红叉"]
                         }
                     )
 


### PR DESCRIPTION
主要流程.
修复了双人魔塔和萌宠神殿交换顺序后, 萌宠神殿完成后不进行退出动作, 导致需触发刷新游戏防卡死才能进行接下来的双人魔塔. 
是由于原本萌宠神殿之后总会刷新游戏, 故未填写结束后动作, 现已修正该问题.