### PR TITLE
v1.5.0-beta.1 兼容自动炸弹时, 无location_to的卡片不被移除, 导致战斗线程崩溃的bug完成修复

### DIFF
--- a/function/core_battle/Card.py
+++ b/function/core_battle/Card.py
@@ -153,7 +153,7 @@ class Card:
             time.sleep(self.click_sleep * (j + 3))
 
             # 如果启动队列模式放卡参数, 使用一次后, 第一个目标位置移动到末位
-            if self.queue:
+            if self.queue and len(self.location) > 0 and len(self.location_to) > 0:
                 self.location.append(self.location[0])
                 self.location.remove(self.location[0])
                 self.location_to.append(self.location_to[0])


### PR DESCRIPTION
如题