### PR TITLE
fix: 修复米苏物流使用默认url时上传失败的问题.

### DIFF
--- a/function/scattered/loots_and_chest_data_save_and_post.py
+++ b/function/scattered/loots_and_chest_data_save_and_post.py
@@ -113,7 +113,8 @@ def loots_and_chests_data_post_to_sever(detail_data, url=None) -> bool:
     :param url: 路径
     :return: 是否发送成功
     """
-    if url is None:
+    if not url:
+        # url 是 None 和 "" 这样的值
         url = 'http://stareabyss.top:5000/faa_server/data_upload/battle_drops'
     try:
         # 校验正确的数据, 输出到FAA数据中心 5s超时
@@ -124,7 +125,6 @@ def loots_and_chests_data_post_to_sever(detail_data, url=None) -> bool:
         return True
     except RequestException as e:
         return False
-
 
 # if __name__ == '__main__':
 #     result = loots_and_chests_data_post_to_sever(


### PR DESCRIPTION
一个极其低级的失误.
导致连通性测试可以通过, 上传总是失败.