### PR TITLE
fix: 为匹配到的卡片添加坐标信息,修复炸弹前放置垫子会因为索引不存在导致线程爆炸问题

### DIFF
--- a/function/core/FAA.py
+++ b/function/core/FAA.py
@@ -289,7 +289,7 @@ class FAA:
                 x2 = card_xy_list[0] + 53
                 y2 = card_xy_list[1] + 70
                 if x1 <= coordinate[0] <= x2 and y1 <= coordinate[1] <= y2:
-                    mat_cards_info.append({'name': name, 'id': card_id})
+                    mat_cards_info.append({'name': name, 'id': card_id,'coordinate_from':card_xy_list})
                     break
 
         # 输出


### PR DESCRIPTION
- 在 FAA.py 文件中，为匹配到的卡片信息增加了 'coordinate_from' 字段
- 这个字段记录了卡片的原始坐标，便于后续处理和追踪
- 虽然这个炸前放垫子实现了，但是实测下来最好还是自行将垫子信息写到战斗方案中，不然用起来比较难蚌