### PR TITLE
fix(自动带卡): 修复背包中存在同一张卡的多种转职, 且要求携带同一类卡的多张卡时, 在特定条件下不会正确报错的问题.

### DIFF
--- a/function/core/FAA_BattlePreparation.py
+++ b/function/core/FAA_BattlePreparation.py
@@ -162,7 +162,12 @@ class BattlePreparation:
                 if match_img_result_dict[card_precise_name]["found"]:
                     scan_card_result_list.append(card_precise_name)
                     scan_card_position_list.append(match_img_result_dict[card_precise_name]["position"])
-                    match_img_result_dict[card_precise_name]["found"] = False
+                    card_name_without_id = card_precise_name.split("-")[0]
+                    # 将所有名称相同(不含转职的 -X)的卡片都设置为 未找到
+                    for i in [0,1,2,3]:
+                        card_be_used = match_img_result_dict.get(f"{card_name_without_id}-{i}")
+                        if card_be_used:
+                            card_be_used["found"] = False
                     break
             else:
                 # 没有找到


### PR DESCRIPTION
具体来说, FAA错误的将同一张卡的多种转职, 作为多张卡进行携带.
但游戏中不允许同一张卡的多种转职被同时携带.
例如 类型带卡需要我 携带 护罩，假设其包含了瓜皮护罩 和 扑克牌护罩，如果我包中有 瓜皮护罩一转和不转，而没有扑克牌护罩，则实际带卡为瓜皮护罩和未能带卡，但不会报错中断作战进而导致房卡错位。 现在在内部带卡预演时, 选定一张卡后, 不仅将自身设为未找到状态, 也会将同卡的其他转职也设为未找到状态. 这解决了问题.