### PR TITLE
fix(浇水 施肥 摘果): 为跟进可重复施肥的游戏改动进行的修正不完全, 导致两个角色间继承尝试次数计数, 进而在罕见情况下产生无限施肥. 对该问题进行了修正.

### DIFF
--- a/function/core/FAA.py
+++ b/function/core/FAA.py
@@ -1699,8 +1699,10 @@ class FAA:
         else:
             return "你游币用完了! 氪不了一点 orz"
 
-    def fed_and_watered(self, try_times=0) -> None:
-        """公会施肥浇水功能，默认尝试次数0, 即从第一个公会开始"""
+    def fed_and_watered(self) -> None:
+        """
+        公会施肥浇水功能
+        """
 
         def goto_guild_and_in_guild():
             """
@@ -1767,7 +1769,10 @@ class FAA:
             return False
 
         def from_guild_to_guild_garden():
-            """进入施肥界面, 正确进入就跳出循环"""
+            """
+            进入施肥界面, 正确进入就跳出循环
+            :return: 是否成功
+            """
             for count_time in range(50):
 
                 T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=745, y=430)
@@ -1794,29 +1799,30 @@ class FAA:
 
         def switch_guild_garden_by_try_times(try_times):
             """根据目前尝试次数, 到达不同的公会"""
-            if try_times != 0:
+            if try_times == 0:
+                return
 
-                # 点击全部公会
-                T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=798, y=123)
+            # 点击全部公会
+            T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=798, y=123)
+            time.sleep(1)
+
+            # 跳转到最后
+            T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=843, y=305)
+            time.sleep(1)
+
+            # 以倒数第二页从上到下为1-4, 第二页为5-8次尝试对应的公会 以此类推
+            for i in range((try_times - 1) // 4 + 1):
+                # 向上翻的页数
+                T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=843, y=194)
                 time.sleep(1)
 
-                # 跳转到最后
-                T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=843, y=305)
-                time.sleep(1)
-
-                # 以倒数第二页从上到下为1-4, 第二页为5-8次尝试对应的公会 以此类推
-                for i in range((try_times - 1) // 4 + 1):
-                    # 向上翻的页数
-                    T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=843, y=194)
-                    time.sleep(1)
-
-                # 点第几个
-                my_dict = {1: 217, 2: 244, 3: 271, 4: 300}
-                T_ACTION_QUEUE_TIMER.add_click_to_queue(
-                    handle=self.handle,
-                    x=810,
-                    y=my_dict[(try_times - 1) % 4 + 1])
-                time.sleep(1)
+            # 点第几个
+            my_dict = {1: 217, 2: 244, 3: 271, 4: 300}
+            T_ACTION_QUEUE_TIMER.add_click_to_queue(
+                handle=self.handle,
+                x=810,
+                y=my_dict[(try_times - 1) % 4 + 1])
+            time.sleep(1)
 
         def do_something_and_exit(try_times):
             """完成素质三连并退出公会花园界面"""
@@ -1836,7 +1842,7 @@ class FAA:
                 template=RESOURCE_P["common"]["退出.png"],
                 match_tolerance=0.95,
                 match_failed_check=7,
-                after_sleep=1,
+                after_sleep=2,
                 click=False
             )
             self.print_debug(text=f"{try_times + 1}/5 次尝试, 浇水后, 已确认无任务完成黑屏")
@@ -1859,16 +1865,17 @@ class FAA:
                 click=False)
             self.print_debug(text=f"{try_times + 1}/5 次尝试, 施肥后, 已确认无任务完成黑屏")
 
-        def fed_and_watered_one_action(try_times):
+        def check_completed_once(try_times):
             """
             :return: bool is completed  , bool is bugged
             """
             # 进入任务界面
-            if not from_guild_to_quest_guild():
+            success = from_guild_to_quest_guild()
+            if not success:
                 return False, True
 
             # 检测施肥任务完成情况 任务是进行中的话为True
-            find = loop_match_ps_in_w(
+            quest_not_completed = loop_match_ps_in_w(
                 source_handle=self.handle,
                 source_root_handle=self.handle_360,
                 template_opts=[
@@ -1897,43 +1904,60 @@ class FAA:
             T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=854, y=55)
             time.sleep(0.5)
 
-            if not find:
-                self.print_debug(text="已完成公会浇水施肥, 尝试次数: {}/5".format(try_times))
+            if not quest_not_completed:
+                self.print_debug(text=f"已完成公会浇水施肥, 尝试次数: {try_times}/5")
                 return True, False
-            else:
-                # 进入施肥界面, 正确进入就跳出循环
-                if not from_guild_to_guild_garden():
-                    return False, True
 
-                # 根据目前尝试次数, 到达不同的公会
-                switch_guild_garden_by_try_times(try_times=try_times)
+            return False, False
 
-                # 完成素质三连并退出公会花园界面
-                do_something_and_exit(try_times=try_times)
-
-                if exit_to_guild_page_and_in_guild():
-                    return False, True
-
-                return False, False
-
-        def fed_and_watered_multi_action(try_times):
+        def fed_and_watered_once(try_times):
             """
-            :return: 完成的尝试次数, 是否是bug
+            :param try_times:
+            :return: 是否出bug
+            """
+
+            # 进入施肥界面, 没有正确进入就跳出循环
+            if not from_guild_to_guild_garden():
+                return True
+
+            # 根据目前尝试次数, 到达不同的公会
+            switch_guild_garden_by_try_times(try_times=try_times)
+
+            # 完成素质三连并退出公会花园界面
+            do_something_and_exit(try_times=try_times)
+
+            success = exit_to_guild_page_and_in_guild()
+            if success:
+                return True
+
+            return False
+
+        def fed_and_watered_multi_action():
+            """
+            :return: 是否完成了任务, 尝试次数, 是否是bug
             """
             # 循环到任务完成
+
+            try_times = 0
+
             while True:
 
-                completed_flag, is_bug = fed_and_watered_one_action(try_times=try_times)
+                is_completed, is_bug = check_completed_once(try_times=try_times)
+
+                if is_completed:
+                    return True, try_times, False
+                if is_bug:
+                    return False, try_times, True
+                if try_times >= 5:
+                    return False, try_times, False
+
+                is_bug = fed_and_watered_once(try_times=try_times)
                 try_times += 1
 
-                if try_times == 5 or is_bug:
-                    # 次数过多, 或 遇上bug
-                    return completed_flag, try_times, True
+                if is_bug:
+                    return False, try_times, True
 
-                if completed_flag:
-                    return completed_flag, try_times, False
-
-        def fed_and_watered_main(try_times):
+        def fed_and_watered_main():
 
             SIGNAL.PRINT_TO_UI.emit(f"[浇水 施肥 摘果 领取] [{self.player}p] 开始执行...")
             self.print_debug(text="开始公会浇水施肥")
@@ -1954,28 +1978,22 @@ class FAA:
                         self.reload_game()
                         break
 
-                # 循环到任务完成或出现bug或超次数
-                completed, try_times, is_bug = fed_and_watered_multi_action(try_times=try_times)
+                # 循环到任务完成或出现bug
+                completed, try_times, is_bug = fed_and_watered_multi_action()
 
                 if is_bug:
-                    if reload_time != 3:
+                    if reload_time < 3:
                         SIGNAL.PRINT_TO_UI.emit(
                             f"[浇水 施肥 摘果 领取] [{self.player}p] 锑食卡住 "
-                            f"本轮循环施肥尝试:{try_times}次 刷新再试({reload_time}/3)")
+                            f"本轮循环施肥尝试:{try_times}次, 刷新, 再试, ({reload_time}/3)")
                         self.reload_game()
                         continue
                     else:
                         SIGNAL.PRINT_TO_UI.emit(
                             f"[浇水 施肥 摘果 领取] [{self.player}p] 锑食卡住 "
-                            f"本轮循环施肥尝试:{try_times}次  刷新跳过({reload_time}/3)")
+                            f"本轮循环施肥尝试:{try_times}次, 刷新, 跳过, ({reload_time}/3)")
                         self.reload_game()
                         break
-
-                if try_times == 5:
-                    SIGNAL.PRINT_TO_UI.emit(
-                        f"[浇水 施肥 摘果 领取] [{self.player}p] 尝试5次, 直接, 肥料不够! 刷新跳过 ")
-                    self.reload_game()
-                    break
 
                 if completed:
                     # 正常完成
@@ -1986,9 +2004,13 @@ class FAA:
                     self.receive_quest_rewards(mode="公会任务")
                     break
 
-            return try_times
+                if try_times >= 5:
+                    SIGNAL.PRINT_TO_UI.emit(
+                        f"[浇水 施肥 摘果 领取] [{self.player}p] 尝试5次, 肥料不够! 刷新, 跳过 ")
+                    self.reload_game()
+                    break
 
-        return fed_and_watered_main(try_times=try_times)
+        fed_and_watered_main()
 
     def use_items_consumables(self) -> None:
 

--- a/function/core/FAA_extra_readimage.py
+++ b/function/core/FAA_extra_readimage.py
@@ -9,7 +9,7 @@ from function.yolo import onnxdetect
 
 
 # 生产者函数
-def producer(time_num, handle, read_queue,is_log,is_gpu):
+def producer(time_num, handle, read_queue, is_log, is_gpu):
     while True:
         # 获取图像并进行目标检测
         result = onnxdetect.get_mouse_position(
@@ -32,17 +32,15 @@ def producer(time_num, handle, read_queue,is_log,is_gpu):
         time.sleep(time_num)
 
 
-
-def read_and_get_return_information(faa,is_log,is_gpu,interval):
+def read_and_get_return_information(faa, is_log, is_gpu, interval):
     # 创建并启动生产者进程
     read_queue = Queue()
     CUS_LOGGER.debug("开始多进程识别特殊老鼠及波次信息")
 
-    p = Process(target=producer, args=(interval, faa.handle, read_queue,is_log,is_gpu))
+    p = Process(target=producer, args=(interval, faa.handle, read_queue, is_log, is_gpu))
     p.start()
 
     return p, read_queue
-
 
 
 def kill_process(process):

--- a/function/core/QMW_1_log.py
+++ b/function/core/QMW_1_log.py
@@ -146,7 +146,7 @@ class QMainWindowLog(QMainWindowLoadUI):
             text="② 有一定的礼卷防翻牌异常",
             time=False)
         SIGNAL.PRINT_TO_UI.emit(
-            text="③ 高星或珍贵不绑卡放储藏室",
+            text="③ 贵重不绑卡/大量多余肥料放储藏室",
             time=False)
         SIGNAL.PRINT_TO_UI.emit(
             text="④ 鼠标不在游戏内, 不玩有反外挂的游戏",
@@ -164,10 +164,6 @@ class QMainWindowLog(QMainWindowLoadUI):
             time=False)
         SIGNAL.PRINT_TO_UI.emit(
             text="新手入门 / 除错 / 深入使用 / 开发者, 都可以在线文档找到相关内容",
-            time=False)
-        SIGNAL.PRINT_TO_UI.emit(
-            text="鼠标在文字或按钮上悬停一会, 会显示部分有用的提示信息哦~",
-            color_level=2,
             time=False)
         SIGNAL.PRINT_TO_UI.emit(
             text="任务或定时器开始运行后, 将锁定点击按钮时的配置文件, 不应用实时更改",

--- a/function/core/Todo.py
+++ b/function/core/Todo.py
@@ -472,14 +472,12 @@ class ThreadTodo(QThread):
         self.model_start_print(text=title_text)
 
         for pid in player:
-            # 归零尝试次数
-            try_times = 0
 
             # 创建进程 -> 开始进程 -> 阻塞主进程
             self.thread_1p = ThreadWithException(
                 target=self.faa_dict[pid].fed_and_watered,
                 name=f"{pid}P Thread - FedAndWatered",
-                kwargs={"try_times": try_times})
+                kwargs={})
             self.thread_1p.start()
             self.thread_1p.join()
 

--- a/function/core/performance_analysis.py
+++ b/function/core/performance_analysis.py
@@ -3,6 +3,7 @@ import os
 import threading
 
 import psutil
+
 from function.widget.GaugePanel import GaugePanel
 
 
@@ -14,6 +15,7 @@ def replace_label_with_gauge(layout_name, label, gauge_panel):
 
     # 将仪表盘控件添加到相同的位置
     layout_name.insertWidget(index, gauge_panel)
+
 
 async def monitor_io(process_ids, stop_event, main_window):
     while True:
@@ -31,7 +33,7 @@ async def monitor_io(process_ids, stop_event, main_window):
                     continue
             main_window.read_bytes_label.setText(f"{total_read_bytes / 1048576:.2f} MB")
             main_window.write_bytes_label.setText(f"{total_write_bytes / 1048576:.2f} MB")
-            main_window.io_gp.setValue((total_read_bytes+total_write_bytes) / 1048576)
+            main_window.io_gp.setValue((total_read_bytes + total_write_bytes) / 1048576)
             # print(f"总读取字节数: {total_read_bytes / 1024 / 1024:.2f} MB")
             # print(f"总写入字节数: {total_write_bytes / 1024 / 1024:.2f} MB")
         await asyncio.sleep(1)
@@ -125,9 +127,10 @@ def run_analysis_in_thread(main_window):
         asyncio.set_event_loop(loop)
         loop.run_until_complete(analysis(main_window))
         loop.close()
-    cpu_gp=GaugePanel("CPU占用率")
-    io_gp=GaugePanel("磁盘读写量/MB",1024)
-    me_gp=GaugePanel("内存使用率")
+
+    cpu_gp = GaugePanel("CPU占用率")
+    io_gp = GaugePanel("磁盘读写量/MB", 1024)
+    me_gp = GaugePanel("内存使用率")
     # 将 GaugePanel 绑定到 main_window 对象
     main_window.cpu_gp = cpu_gp
     main_window.io_gp = io_gp

--- a/resource/ui/FAA_3.0.ui
+++ b/resource/ui/FAA_3.0.ui
@@ -104,6 +104,9 @@
 }</string>
        </property>
        <layout class="QHBoxLayout" name="title_tag">
+        <property name="spacing">
+         <number>5</number>
+        </property>
         <property name="topMargin">
          <number>5</number>
         </property>
@@ -142,15 +145,15 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="Title_Text">
+         <widget class="QLabel" name="Title_Text_2">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="text">
-           <string>  FAA  本软件免费且开源</string>
+           <string>   FAA</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -160,14 +163,14 @@
         <item>
          <widget class="QLabel" name="Title_Version">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>200</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
@@ -175,7 +178,7 @@
            <string notr="true"/>
           </property>
           <property name="text">
-           <string>版本号  </string>
+           <string>版本号</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -197,6 +200,22 @@
             <number>0</number>
            </property>
           </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="Title_Text">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>本软件免费且开源  鼠标悬停在控件上可查看提示信息</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
          </widget>
         </item>
         <item>
@@ -494,6 +513,9 @@ border:none</string>
                    <property name="tabletTracking">
                     <bool>false</bool>
                    </property>
+                   <property name="toolTip">
+                    <string>该参数由FAA自动获取</string>
+                   </property>
                    <property name="autoFillBackground">
                     <bool>false</bool>
                    </property>
@@ -577,6 +599,9 @@ border:none</string>
                    </property>
                    <property name="tabletTracking">
                     <bool>false</bool>
+                   </property>
+                   <property name="toolTip">
+                    <string>请使用下方拖动功能, 获取该参数</string>
                    </property>
                    <property name="autoFillBackground">
                     <bool>false</bool>
@@ -672,6 +697,9 @@ border:none</string>
                    <property name="tabletTracking">
                     <bool>false</bool>
                    </property>
+                   <property name="toolTip">
+                    <string>请使用下方拖动功能, 获取该参数</string>
+                   </property>
                    <property name="autoFillBackground">
                     <bool>false</bool>
                    </property>
@@ -752,6 +780,9 @@ border:none</string>
                    </property>
                    <property name="tabletTracking">
                     <bool>false</bool>
+                   </property>
+                   <property name="toolTip">
+                    <string>请使用下方拖动功能, 获取该参数</string>
                    </property>
                    <property name="autoFillBackground">
                     <bool>false</bool>
@@ -841,6 +872,9 @@ border:none</string>
                      <height>16777215</height>
                     </size>
                    </property>
+                   <property name="toolTip">
+                    <string>您游戏角色的等级</string>
+                   </property>
                    <property name="minimum">
                     <number>1</number>
                    </property>
@@ -918,6 +952,9 @@ border:none</string>
                      <width>200</width>
                      <height>16777215</height>
                     </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>您游戏角色的等级</string>
                    </property>
                    <property name="minimum">
                     <number>1</number>
@@ -2528,7 +2565,7 @@ Link Start</string>
                 </size>
                </property>
                <property name="text">
-                <string>强制默认方案1</string>
+                <string>强制 1-通用-1P</string>
                </property>
               </widget>
              </item>
@@ -2560,7 +2597,7 @@ Link Start</string>
 双倍掉落：可用，但无必要</string>
                </property>
                <property name="text">
-                <string>公会任务 *</string>
+                <string>公会任务</string>
                </property>
               </widget>
              </item>
@@ -2697,7 +2734,7 @@ Link Start</string>
                 </size>
                </property>
                <property name="text">
-                <string>据配置</string>
+                <string>序列-&gt;</string>
                </property>
               </widget>
              </item>
@@ -3293,7 +3330,7 @@ Link Start</string>
 双倍掉落：可用，但无必要</string>
                </property>
                <property name="text">
-                <string>情侣任务 *</string>
+                <string>情侣任务</string>
                </property>
               </widget>
              </item>
@@ -4965,7 +5002,7 @@ Link Start</string>
 </string>
                </property>
                <property name="text">
-                <string>领取奖励 *</string>
+                <string>领取奖励</string>
                </property>
               </widget>
              </item>
@@ -5507,7 +5544,7 @@ Link Start</string>
                 </size>
                </property>
                <property name="text">
-                <string>强制默认方案1</string>
+                <string>强制 1-通用-2P</string>
                </property>
               </widget>
              </item>
@@ -5893,7 +5930,7 @@ Link Start</string>
 双倍掉落：可用，但无必要</string>
                </property>
                <property name="text">
-                <string>悬赏任务 *</string>
+                <string>悬赏任务</string>
                </property>
               </widget>
              </item>
@@ -6323,7 +6360,7 @@ Link Start</string>
                 <string>包含了：温馨礼包 / VIP签到 / 每日签到 / 美食活动 / 塔罗 / 法老 / 会长发任务 / 营地钥匙 / 领取月卡 / 温馨礼包(高级)</string>
                </property>
                <property name="text">
-                <string>签到 *</string>
+                <string>签到</string>
                </property>
               </widget>
              </item>
@@ -7177,7 +7214,7 @@ Link Start</string>
                 </size>
                </property>
                <property name="text">
-                <string>事项 *推荐开启</string>
+                <string>事项</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -7381,31 +7418,6 @@ Link Start</string>
                </property>
               </widget>
              </item>
-             <item row="7" column="2">
-              <widget class="QLabel" name="Customize_MaxTimes">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>50</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>2000</width>
-                 <height>50</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>据配置</string>
-               </property>
-              </widget>
-             </item>
              <item row="5" column="6">
               <widget class="QComboBox" name="Warrior_Deck">
                <property name="sizePolicy">
@@ -7509,7 +7521,7 @@ Link Start</string>
                 </size>
                </property>
                <property name="toolTip">
-                <string>允许您编辑任意关卡组合进行作战.
+                <string>允许您自由编辑[关卡/事项]进行作战.
 推荐您在对FAA有一定了解后再使用.</string>
                </property>
                <property name="text">
@@ -7572,31 +7584,6 @@ Link Start</string>
                  <string>6</string>
                 </property>
                </item>
-              </widget>
-             </item>
-             <item row="7" column="1">
-              <widget class="QLabel" name="Customize_Group">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>50</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>2000</width>
-                 <height>50</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>据配置</string>
-               </property>
               </widget>
              </item>
              <item row="12" column="6">
@@ -8303,6 +8290,9 @@ Link Start</string>
                  <height>50</height>
                 </size>
                </property>
+               <property name="toolTip">
+                <string>大赛功能, 暂不支持自动带卡! 必须手动编辑!</string>
+               </property>
                <item>
                 <property name="text">
                  <string>1</string>
@@ -8964,6 +8954,31 @@ Link Start</string>
                 </widget>
                </item>
               </layout>
+             </item>
+             <item row="7" column="2">
+              <widget class="QLabel" name="Customize_Deck_2">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>60</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>60</width>
+                 <height>100</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>起始编号-&gt;</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </item>
@@ -12285,15 +12300,11 @@ FAA放卡核心原理简述:
                 </layout>
                </item>
                <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_14">
-                 <item>
-                  <widget class="QCheckBox" name="Startup">
-                   <property name="text">
-                    <string>开机启动</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
+                <widget class="QCheckBox" name="Startup">
+                 <property name="text">
+                  <string>电脑开机后, 启动FAA</string>
+                 </property>
+                </widget>
                </item>
                <item>
                 <widget class="QCheckBox" name="open360">
@@ -12556,7 +12567,7 @@ FAA放卡核心原理简述:
                     </size>
                    </property>
                    <property name="text">
-                    <string>360游戏大厅.exe</string>
+                    <string>360游戏大厅路径</string>
                    </property>
                    <property name="alignment">
                     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>


### PR DESCRIPTION
核心矛盾: try times 的定义发生更改后代码没有做相应更新. (总计次数 -> 单角色次数)
* 老版游戏无法对同一公会多次施肥，因此需要大量尝试，并让2P继承1P的进度继续，防止重新对近百个公会做无效尝试
* 新版则不再需要，仅需尝试1+3个公会即可顺利完成任务. 第一个公会可能存在没有种树的问题.

* 后果1
    * 1P计数继承到2P后，如果1P正好是5次完成任务，继承次数的2P可能直接绕过计数==5的中断机制，导致无限施肥产生。
* 后果2
    * 1P完成三次任务后，计数为3
    * 2P完成两次任务后，计数为2，触发5次一reload的防卡死.
    * reload后完成任务.