### PR TITLE
fix(战斗流程): 修复一项重大bug. 区分战斗的模式id和实际地图id. 以修复用户在自建房随意输入关卡id后, 错误的id为参数生成的战斗结果, 被上传至米苏物流, 造成数据污染的问题. 并增加了更精细的调试信息, 以测试该问题.

### DIFF
--- a/function/core/faa/faa_battle_preparation.py
+++ b/function/core/faa/faa_battle_preparation.py
@@ -907,7 +907,7 @@ class BattlePreparation:
             # 定义保存路径和文件名格式
             img_path = "{}\\{}_{}P_{}.png".format(
                 PATHS["logs"] + "\\loots_image",
-                stage_info["id"],
+                stage_info["id"],  # 注意 此处一定要使用内部一定正确的id! b_id可能是用户随笔输入的
                 player,
                 time.strftime('%Y-%m-%d_%H-%M-%S', time.localtime())
             )

--- a/function/core/faa/faa_core.py
+++ b/function/core/faa/faa_core.py
@@ -146,18 +146,26 @@ class FAABase:
     """"对flash游戏界面或自身参数的最基础 [检测]"""
 
     def check_level(self: "FAA") -> bool:
-        """检测角色等级和关卡等级(调用于输入关卡信息之后)"""
+        """
+        检测角色等级和关卡等级
+        调用于输入关卡信息之后
+        """
         if self.character_level < self.stage_info["level"]:
             return False
         else:
             return True
 
     def check_stage_id_is_true(self: "FAA") -> bool:
-        """检查关卡ID是否合法"""
-        stage_id = self.stage_info["id"]
-        if stage_id in EXTRA.TRUE_STAGE_ID:
-            return True
-        return False
+        """
+        检查关卡ID是否合法, id指的是 FAA内的模式标识. b_id为关卡的战斗用地图信息id.
+        模式标识: 用于上传到米苏物流等用途.
+        战斗标识: 默认复制自模式标识, 如果为自建房, 则来自用户的输入, 之后还会被关卡名称的OCR做二次修正.
+        """
+        if self.stage_info["id"] not in EXTRA.TRUE_STAGE_ID:
+            return False
+        if self.stage_info["b_id"] not in EXTRA.TRUE_STAGE_ID:
+            return False
+        return True
 
     def check_stage_is_active(self: "FAA") -> bool:
         """关卡是否保持激活"""
@@ -220,9 +228,12 @@ class FAABase:
             quest_card=None,
             ban_card_list=None,
             max_card_num=None,
-            battle_plan_uuid: str = "00000000-0000-0000-0000-000000000000") -> None:
+            battle_plan_uuid: str = "00000000-0000-0000-0000-000000000000",
+            is_cu: bool = False,
+    ) -> None:
         """
         战斗相关参数的re_init
+        :param is_cu: 是否为自建房, 此类战斗需要修改stage id 为 CU-0-0, 以防用户自建房随便输入StageID污染数据集!!!
         :param is_group: 是否组队
         :param is_main: 是否是主要账号(单人为True 双人房主为True)
         :param need_key: 是否使用钥匙
@@ -251,7 +262,10 @@ class FAABase:
         # 如果缺失, 外部的检测函数会拦下来不继续的
         self.battle_plan = g_resources.RESOURCE_B.get(battle_plan_uuid, None)
 
-        self.stage_info = read_json_to_stage_info(stage_id)
+        if not is_cu:
+            self.stage_info = read_json_to_stage_info(stage_id)
+        else:
+            self.stage_info = read_json_to_stage_info(stage_id="CU-0-0", stage_id_for_battle=stage_id)
 
     """战斗完整的过程中的任务函数"""
 

--- a/function/globals/EXTRA.py
+++ b/function/globals/EXTRA.py
@@ -71,15 +71,15 @@ def get_true_stage_id():
     # 跨服
     stage_ids += generate_stage_ids("CS", [1, 6], [1, 8])
     # 魔塔
-    stage_ids += generate_stage_ids("MT", [1, 1], [1, 165])
-    stage_ids += generate_stage_ids("MT", [2, 2], [1, 100])
+    stage_ids += generate_stage_ids("MT", [1, 1], [0, 165])  # 0为爬塔模式
+    stage_ids += generate_stage_ids("MT", [2, 2], [0, 100])  # 0为爬塔模式
     stage_ids += generate_stage_ids("MT", [3, 3], [1, 4])
     # 宠物
-    stage_ids += generate_stage_ids("PT", [0, 0], [1, 25])
+    stage_ids += generate_stage_ids("PT", [0, 0], [0, 25])  # 0为爬塔模式
     # 悬赏
     stage_ids += generate_stage_ids("OR", [0, 0], [1, 4])
     # 假期
-    stage_ids += generate_stage_ids("HH", [0, 0], [0, 0])
+    stage_ids += ["HH-0-0"]
     # 生肖
     stage_ids += generate_stage_ids("CZ", [0, 0], [1, 4])
 

--- a/function/scattered/loots_and_chest_data_save_and_post.py
+++ b/function/scattered/loots_and_chest_data_save_and_post.py
@@ -25,7 +25,8 @@ def loots_and_chests_statistics_to_json(faa: "FAA", loots_dict, chests_dict) -> 
     player = faa.player
 
     file_path = "{}\\result_json\\{}P掉落汇总.json".format(PATHS["logs"], player)
-    stage_name = faa.stage_info["id"]
+    # 注意 此处一定要使用内部一定正确的id! b_id可能是用户随笔输入的
+    stage_id = faa.stage_info["id"]
 
     # 获取本次战斗是否使用了钥匙
     if faa.is_used_key:
@@ -43,7 +44,7 @@ def loots_and_chests_statistics_to_json(faa: "FAA", loots_dict, chests_dict) -> 
         json_data = {}
 
     # 检查键 不存在添加
-    json_data_stage = json_data.setdefault(stage_name, {})
+    json_data_stage = json_data.setdefault(stage_id, {})
     json_data_used_key = json_data_stage.setdefault(used_key_str, {})
     json_data_loots = json_data_used_key.setdefault("loots", {})
     json_data_chests = json_data_used_key.setdefault("chests", {})
@@ -72,11 +73,12 @@ def loots_and_chests_detail_to_json(faa: "FAA", loots_dict, chests_dict) -> dict
     """
 
     file_path = "{}\\result_json\\{}P掉落明细.json".format(PATHS["logs"], faa.player)
-    stage_name = faa.stage_info["id"]
+    # 注意 此处一定要使用内部一定正确的id! b_id可能是用户随笔输入的
+    stage_id = faa.stage_info["id"]
     new_data = {
         "version": EXTRA.VERSION,  # 版本号
         "timestamp": time.time(),  # 时间戳
-        "stage": stage_name,  # 关卡代号
+        "stage": stage_id,  # 关卡代号
         "is_used_key": faa.is_used_key,
         "loots": loots_dict,
         "chests": chests_dict

--- a/function/scattered/match_ocr_text/text_to_battle_info.py
+++ b/function/scattered/match_ocr_text/text_to_battle_info.py
@@ -22,7 +22,7 @@ def food_texts_to_battle_info(texts, self):
         "木盘子",
         "咖啡粉",
         "麦芽糖",
-        "冰淇淋",
+        "冰激凌",
         "幻幻鸡",
         "创造神",
         "魔法软糖"

--- a/function/scattered/read_json_to_stage_info.py
+++ b/function/scattered/read_json_to_stage_info.py
@@ -32,6 +32,7 @@ def read_json_to_stage_info(stage_id, stage_id_for_battle=None):
         stage_id_for_battle = stage_id
     stage_info = stages_info["default"]
     stage_info["id"] = stage_id
+    stage_info["b_id"] = stage_id_for_battle
 
     # 拆分关卡名称
     stage_0, stage_1, stage_2 = stage_id_for_battle.split("-")  # type map stage

--- a/resource/ui/FAA_3.0.ui
+++ b/resource/ui/FAA_3.0.ui
@@ -5093,6 +5093,12 @@ Link Start</string>
                  <property name="tabletTracking">
                   <bool>false</bool>
                  </property>
+                 <property name="toolTip">
+                  <string>此处的关卡, 用于:
+1. 提供关卡承载卡和障碍物等关卡信息. 
+2. 若开启全局/关卡方案, 据此获取关卡战斗方案.
+如不需要此服务, 可填写NO-1-7之类的可用关卡代号.</string>
+                 </property>
                  <property name="autoFillBackground">
                   <bool>false</bool>
                  </property>
@@ -6584,8 +6590,9 @@ Link Start</string>
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>该功能仅能单独启用!
-不可与其他功能配合!</string>
+                  <string>* 该功能仅能单独启用!不可与其他功能配合!
+* 该功能仅用于带其他人刷关.通常的战斗, 均应该使用常规单本连战. 
+* 该模式下, !!!不含任何防卡死!!! 机制!</string>
                  </property>
                  <property name="text">
                   <string>自建房对战</string>
@@ -9289,7 +9296,7 @@ Link Start</string>
                 <property name="geometry">
                  <rect>
                   <x>2</x>
-                  <y>-1660</y>
+                  <y>0</y>
                   <width>560</width>
                   <height>2300</height>
                  </rect>


### PR DESCRIPTION
* 该问题的来源
    * 此前一项补丁, 允许用户在自建房处自由输入stageid.
    * 并以该id获取关卡信息, 全局关卡方案等参数, 以支持更方便的自建房.
    * 此前FAA未能区分业务逻辑的id(除自建房外, 还包括魔塔自动爬塔即层数为0时的情况)与实际地图的id.
* 后果
    * 这导致少量未知关卡名称的脏数据流入了米苏物流.
    * 关卡A中流入了部分关卡B的数据.(因为用户可以自由输入关卡id)
* 解决方案
    * 明确划分两种关卡id的来源和用途.
        * 业务id为所有地图id加上 CU-0-0, MT-1-0, MT-2-0, PT-0-0. 用于米苏物流的输出和内部的模式判别. 
        * 关卡id, 默认继承自业务id, 如果为自建房, 则修改为用户的输入, 之后再由关卡名称OCR进行二次更正. 用于获取关卡的信息和全局方案.
    * 增加更多调试信息以纠错.
    * 加入白名单机制. 要求用户必须输入白名单内的关卡id. 否则对应操作直接跳过.