### PR TITLE
perf(全局&关卡方案): 对于仅单人关卡, 2P不再使用1P方案, 对于可双人关卡的单人作战则不变.

### DIFF
--- a/function/core/todo.py
+++ b/function/core/todo.py
@@ -1269,6 +1269,11 @@ class ThreadTodo(QThread):
                     battle_plan_1p_ = g_plan["battle_plan"][0]
                     battle_plan_2p_ = g_plan["battle_plan"][1]
                 else:
+                    if "WB" in stage_id or "MT-1" in stage_id or "MT-3" in stage_id:
+                        # 世界Boss关卡 魔塔单人和密室 完全单人关卡, 使用 1P 和 2P各自的 方案
+                        battle_plan_1p_ = g_plan["battle_plan"][0]
+                        battle_plan_2p_ = g_plan["battle_plan"][1]
+                    else:
                         # 可组队关卡, 但设置了仅单人作战
                         battle_plan_1p_ = g_plan["battle_plan"][0]
                         battle_plan_2p_ = g_plan["battle_plan"][0]


### PR DESCRIPTION
为了在可双人的关卡单人作战时, 若在全局&关卡方案设置了仅作为辅助的不完整的2P方案, 如果1P和2P使用各自的方案, 2P将无法完成单人作战. 修改后, 将根据该关卡本身是否为仅单人, 进行判定.
双人关卡双人：使用各自方案.
双人关卡单人：都用1P方案.
单人关卡单人：都用1P方案(旧) -> 使用各自方案(新)