### PR TITLE
refactor(路径初始化): 显式执行启动目录检查

### DIFF
--- a/function/faa_main.py
+++ b/function/faa_main.py
@@ -12,6 +12,9 @@ def main():
 
     # 锁定主进程
     multiprocessing.freeze_support()
+    # 启动主程序时显式检查并补齐必需目录，避免导入 PATHS 时产生文件系统副作用
+    from function.globals.get_paths import check_paths
+    check_paths()
     # 展示加载窗口
     loading.show()
     loading.update_progress(1)

--- a/function/globals/get_paths.py
+++ b/function/globals/get_paths.py
@@ -108,8 +108,6 @@ def check_paths():
     print("启动前路径检测 完成")
 
 
-# 创建所有缺失的目录
-check_paths()
-
 if __name__ == '__main__':
+    check_paths()
     print(PATHS)


### PR DESCRIPTION
## 变更

- 移除 `get_paths.py` 导入阶段自动执行的 `check_paths()`。
- 在 `faa_main.main()` 启动流程中显式检查并补齐必需目录。
- 保留基于 `LICENSE` 的根目录识别与协议文件保护逻辑。

## 检查

- `python -m compileall -q function\faa_main.py function\globals\get_paths.py`
- 单独导入 `PATHS` 不再输出路径检查日志