### PR TITLE
chore(gitignore): 忽略本地开发资源目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ logs/
 
 # 忽略 main.spec
 main.spec
+
+# 忽略其他开发资源
+resource_other/


### PR DESCRIPTION
## 概要
* 将 resource_other/ 加入 .gitignore。
* 避免本地截图、临时资料和开发资源进入 Git 状态。

## 验证
* git diff --check