### PR TITLE
fix(启动): 补充 qmw_3_service 的 os 导入

### DIFF
--- a/function/core/qmw_3_service.py
+++ b/function/core/qmw_3_service.py
@@ -1,5 +1,6 @@
 ﻿import datetime
 import json
+import os
 import random
 import shutil
 import sqlite3


### PR DESCRIPTION
## 内容
- 补充 function/core/qmw_3_service.py 缺失的 os 导入。
- 修复启动时 guild_manager_table_load_data 使用 os.path.join 导致的 NameError。

## 校验
- 已执行 uv run python -m py_compile function/core/qmw_3_service.py。
- 已执行 git diff --check。