### PR TITLE
fix: 兼容普通用户无 Git 的热更新状态检测

### DIFF
--- a/function/common/update_state.py
+++ b/function/common/update_state.py
@@ -23,14 +23,24 @@ def read_extra_version(project_root: Path) -> str:
 
 
 def run_git(project_root: Path, args: list[str]) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=project_root,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
+    """
+    Run a Git command when a developer Git environment is available.
+
+    普通用户的热更新不依赖本地 Git。这里的 Git 调用只用于开发者工作区状态展示；
+    如果用户没有安装 Git、Git 不在 PATH 中，或当前环境无法启动 Git，则返回空字符串，
+    让上层自动回退到 update_state.json / EXTRA.VERSION。
+    """
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except (FileNotFoundError, OSError):
+        return ""
     if result.returncode != 0:
         return ""
     return result.stdout.strip()

--- a/function/core/qmw_3_service.py
+++ b/function/core/qmw_3_service.py
@@ -332,10 +332,12 @@ class QMainWindowService(QMainWindowLoadSettings):
         """
         local_state = local_state or detect_local_state(Path(PATHS["root"]))
         release_entry = release_entry or {}
+        # 普通用户热更新不依赖本地 Git；Git 工作区状态只用于开发者环境的额外诊断。
+        source_key = local_state.get("source")
         source_map = {
-            "git": "Git 工作区",
-            "update_state": "本地更新状态文件",
-            "extra_version": "EXTRA.VERSION",
+            "git": "Git 工作区（开发者）",
+            "update_state": "本地更新状态文件（普通用户无 Git 属正常）",
+            "extra_version": "EXTRA.VERSION（普通用户无 Git 属正常）",
         }
         version = local_state.get("version") or "未知"
         tag = local_state.get("tag") or "未记录"
@@ -344,9 +346,11 @@ class QMainWindowService(QMainWindowLoadSettings):
         commit = local_state.get("commit") or ""
         commit_text = commit[:12] if commit else "未记录"
         branch = local_state.get("branch") or "未记录"
-        source = source_map.get(local_state.get("source"), local_state.get("source") or "未知")
+        source = source_map.get(source_key, source_key or "未知")
         merged_at = release_entry.get("merged_at") or local_state.get("merged_at") or "未记录"
-        dirty_text = "有本地改动" if local_state.get("dirty") else "干净"
+        dirty_text = (
+            "有本地改动" if local_state.get("dirty") else "干净"
+        ) if source_key == "git" else "未检测（仅开发者 Git 工作区）"
 
         self.UpdateStateLabel.setText(
             f"当前版本：{version}    Tag：{tag}    PR：{pr_text}    "


### PR DESCRIPTION
## 内容
* 将热更新本地状态里的 `git` 调用改为可选开发者能力，普通用户未安装 Git 时不再抛出异常。
* 无 Git 或非 Git 工作区时继续回退到 `update_cache/update_state.json` / `EXTRA.VERSION`。
* 更新页顶部状态文案标明：普通用户无 Git 属正常，脏工作区状态仅开发者 Git 工作区检测。

## 校验
* 已通过 `uv run python -B -m py_compile function\common\update_state.py function\core\qmw_3_service.py`
* 已通过无 Git 场景模拟：`subprocess.run` 抛 `FileNotFoundError` 时可回退到 `update_state.json`
* 已通过 `git diff --check origin/main codex/hot-update-no-git-fallback-20260628`