### PR TITLE
perf(热更新): 优化版本状态展示与打包记录

### DIFF
--- a/function/common/update_state.py
+++ b/function/common/update_state.py
@@ -196,5 +196,84 @@ def detect_local_state(project_root: Path) -> dict[str, Any]:
     return detected
 
 
+def apply_update_entry_metadata(state: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
+    if not entry:
+        return state
+
+    for key in ("pr", "summary", "title", "url", "merged_at"):
+        if not state.get(key) and entry.get(key):
+            state[key] = entry[key]
+    return state
+
+
+def find_cached_update_entry(project_root: Path, state: dict[str, Any]) -> dict[str, Any]:
+    try:
+        from function.common.update_manifest import load_manifest_cache
+    except ImportError:
+        return {}
+
+    try:
+        cache = load_manifest_cache(project_root)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+
+    tag = state.get("tag")
+    commit = state.get("commit")
+    for bucket in ("versions", "dev_commits"):
+        for entry in cache.get(bucket, []):
+            if tag and entry.get("tag") == tag:
+                return entry
+            if commit and entry.get("commit") == commit:
+                return entry
+    return {}
+
+
+def fetch_remote_update_entry(state: dict[str, Any]) -> dict[str, Any]:
+    commit = state.get("commit")
+    if not commit:
+        return {}
+
+    try:
+        from function.common.update_manifest import GitHubClient, build_dev_entry, build_version_entry
+
+        client = GitHubClient()
+        commit_payload = client.get_commit(commit)
+        pulls = client.get_pulls_for_commit(commit)
+    except Exception:
+        return {}
+
+    tag = state.get("tag")
+    if tag:
+        return build_version_entry(tag, commit_payload, pulls)
+    return build_dev_entry(commit_payload, pulls)
+
+
+def fill_packaged_merge_metadata(project_root: Path, state: dict[str, Any]) -> dict[str, Any]:
+    """
+    补齐打包产物的 PR 合并时间。
+
+    打包状态最初来自本地 Git，只能得到 commit/tag/PR 号，不能直接得到 GitHub PR
+    的 merged_at。这里先用本地 manifest 缓存，再请求 GitHub；如果网络不可用，则回退
+    到本地 merge commit 的提交时间，避免正式包的“时间”长期显示为未记录。
+    """
+    if state.get("merged_at"):
+        return state
+
+    state = apply_update_entry_metadata(state, find_cached_update_entry(project_root, state))
+    if state.get("merged_at"):
+        return state
+
+    state = apply_update_entry_metadata(state, fetch_remote_update_entry(state))
+    if state.get("merged_at"):
+        return state
+
+    commit_time = run_git(project_root, ["log", "-1", "--format=%cI"])
+    if commit_time:
+        state["merged_at"] = commit_time
+    return state
+
+
 def write_packaged_update_state(project_root: Path, dest_root: Path) -> Path:
-    return write_update_state(dest_root, build_update_state(project_root, "packaged_at"))
+    state = build_update_state(project_root, "packaged_at")
+    state = fill_packaged_merge_metadata(project_root, state)
+    return write_update_state(dest_root, state)

--- a/function/core/qmw_3_service.py
+++ b/function/core/qmw_3_service.py
@@ -223,6 +223,7 @@ class QMainWindowService(QMainWindowLoadSettings):
         self.dev_manifest_pages = 1
         self.window_update_backup_manager = None
         self.window_tip_update = QMWTipUpdate()
+        self.setup_update_state_labels()
         self.refresh_update_state_label()
         self.update_progress_started_at = None
         self.update_progress_step = "空闲"
@@ -322,6 +323,23 @@ class QMainWindowService(QMainWindowLoadSettings):
         for warning in warnings:
             SIGNAL.PRINT_TO_UI.emit(f"[更新状态] {warning}", color_level=1, time=False)
 
+    def setup_update_state_labels(self):
+        """绑定更新页顶部 2x2 状态标签。"""
+        self.update_state_labels = {
+            "version": self.UpdateVersionInfoLabel,
+            "node": self.UpdateNodeInfoLabel,
+            "branch": self.UpdateBranchInfoLabel,
+            "source": self.UpdateSourceInfoLabel,
+        }
+        if hasattr(self, "UpdateStateGridLayout"):
+            self.UpdateStateGridLayout.setColumnStretch(0, 1)
+            self.UpdateStateGridLayout.setColumnStretch(1, 1)
+
+        for label in self.update_state_labels.values():
+            label.setWordWrap(True)
+            label.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop)
+            label.setTextInteractionFlags(QtCore.Qt.TextInteractionFlag.TextSelectableByMouse)
+
     def refresh_update_state_label(self, local_state: dict | None = None, release_entry: dict | None = None):
         """
         刷新更新页顶部的本地版本状态摘要。
@@ -332,13 +350,11 @@ class QMainWindowService(QMainWindowLoadSettings):
         """
         local_state = local_state or detect_local_state(Path(PATHS["root"]))
         release_entry = release_entry or {}
-        # 普通用户热更新不依赖本地 Git；Git 工作区状态只用于开发者环境的额外诊断。
-        source_key = local_state.get("source")
-        source_map = {
-            "git": "Git 工作区（开发者）",
-            "update_state": "本地更新状态文件（普通用户无 Git 属正常）",
-            "extra_version": "EXTRA.VERSION（普通用户无 Git 属正常）",
-        }
+        for key, text in self._build_update_state_texts(local_state, release_entry).items():
+            self.update_state_labels[key].setText(text)
+
+    def _build_update_state_texts(self, local_state: dict, release_entry: dict) -> dict[str, str]:
+        """生成更新页顶部 2x2 状态标签文本。"""
         version = local_state.get("version") or "未知"
         tag = local_state.get("tag") or "未记录"
         pr = local_state.get("pr")
@@ -346,17 +362,53 @@ class QMainWindowService(QMainWindowLoadSettings):
         commit = local_state.get("commit") or ""
         commit_text = commit[:12] if commit else "未记录"
         branch = local_state.get("branch") or "未记录"
-        source = source_map.get(source_key, source_key or "未知")
         merged_at = release_entry.get("merged_at") or local_state.get("merged_at") or "未记录"
-        dirty_text = (
-            "有本地改动" if local_state.get("dirty") else "干净"
-        ) if source_key == "git" else "未检测（仅开发者 Git 工作区）"
+        return {
+            "version": f"当前版本：{version} {self._format_version_note(version, tag)}",
+            "node": f"更新节点：PR {pr_text} / {commit_text} / {merged_at}",
+            "branch": f"分支：{self._format_update_branch(branch)}",
+            "source": f"版本信息和当前状态来源：{self._format_update_state_source(local_state)}",
+        }
 
-        self.UpdateStateLabel.setText(
-            f"当前版本：{version}    Tag：{tag}    PR：{pr_text}    "
-            f"Commit：{commit_text}    分支：{branch}    来源：{source}    "
-            f"时间：{merged_at}    状态：{dirty_text}"
+    @staticmethod
+    def _format_version_note(version: str, tag: str) -> str:
+        if version != "未知" and version == tag:
+            return "（内部版本号与Git Tag一致，为标准发行版）"
+        return "（无GitTag，为中间版本，有可能不稳定的特性）"
+
+    @staticmethod
+    def _format_update_branch(branch: str) -> str:
+        if branch.lower() == "main":
+            return "Main（发行主分支）"
+        if not branch or branch == "未记录":
+            return "未记录（无法确认当前是否为主分支）"
+        return f"{branch}（开发者个人分支 注：本模块请务必在主分支使用）"
+
+    @staticmethod
+    def _format_update_state_source(local_state: dict) -> str:
+        source_key = local_state.get("source")
+        if source_key == "git":
+            return "Git工作区 - 有本地改动" if local_state.get("dirty") else "Git工作区 - 干净"
+        if source_key == "update_state":
+            return "用户本地 - 版本状态文件正常运作"
+        return "用户本地 - 版本状态文件异常运作，使用项目全局VERSION变量"
+
+    def _ensure_update_allowed_on_main_branch(self) -> bool:
+        local_state = detect_local_state(Path(PATHS["root"]))
+        branch = local_state.get("branch") or ""
+        if branch.lower() == "main":
+            return True
+
+        branch_text = branch or "未记录"
+        self.refresh_update_state_label(local_state=local_state)
+        message = (
+            f"当前检测到的分支：{branch_text}\n\n"
+            "为避免在开发者个人分支误触热更新并覆盖工作区，本功能只允许在 main 主分支使用。\n"
+            "请切换到 main 分支，或使用标准打包版后再执行更新。"
         )
+        SIGNAL.PRINT_TO_UI.emit(f"[更新状态] 已阻止非 main 分支执行更新。当前分支：{branch_text}", color_level=1)
+        QMessageBox.warning(self, "当前分支不允许执行更新", message)
+        return False
 
     def refresh_update_progress_label(self):
         """刷新更新页的当前操作阶段和等待时间。"""
@@ -1470,6 +1522,9 @@ class QMainWindowService(QMainWindowLoadSettings):
 
     def click_btn_normal_update(self):
         """准备并确认应用用户在表格中选中的更新目标。"""
+        if not self._ensure_update_allowed_on_main_branch():
+            return
+
         target = self._selected_update_target()
         if not target:
             QMessageBox.information(self, "暂无可用更新", "请先点击“检查更新”刷新正式版本列表。")

--- a/resource/ui/FAA_3.0.ui
+++ b/resource/ui/FAA_3.0.ui
@@ -7227,14 +7227,66 @@ FAA放卡核心原理简述:
            <item>
             <layout class="QVBoxLayout" name="UpdateLayout">
              <item>
-              <widget class="QLabel" name="UpdateStateLabel">
-               <property name="text">
-                <string>当前版本状态：读取中...</string>
+              <layout class="QGridLayout" name="UpdateStateGridLayout">
+               <property name="horizontalSpacing">
+                <number>24</number>
                </property>
-               <property name="wordWrap">
-                <bool>true</bool>
+               <property name="verticalSpacing">
+                <number>6</number>
                </property>
-              </widget>
+               <item row="0" column="0">
+                <widget class="QLabel" name="UpdateVersionInfoLabel">
+                 <property name="text">
+                  <string>当前版本：读取中...</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QLabel" name="UpdateNodeInfoLabel">
+                 <property name="text">
+                  <string>更新节点：读取中...</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QLabel" name="UpdateBranchInfoLabel">
+                 <property name="text">
+                  <string>分支：读取中...</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QLabel" name="UpdateSourceInfoLabel">
+                 <property name="text">
+                  <string>版本信息和当前状态来源：读取中...</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
              <item>
               <widget class="QLabel" name="UpdateProgressLabel">


### PR DESCRIPTION
* 检查更新页改为四个 QLabel 的 2x2 状态布局，调整当前版本、更新节点、分支、状态来源文案。
* 打包写入 update_state.json 时补齐 PR 合并时间，避免发行包显示未记录。
* 更新至选中版本前限制当前分支必须为 main，避免开发者个人分支误触热更新。