### PR TITLE
feat(配置迁移): 完善用户配置迁移规则

### DIFF
--- a/docs/ai_agent_todo_list/版本更新与配置迁移方案TODO.md
+++ b/docs/ai_agent_todo_list/版本更新与配置迁移方案TODO.md
@@ -61,7 +61,8 @@
 - [x] 新增 `function/core/settings_migration.py`
   - 抽出无 UI 的迁移核心。
   - 支持 `migrate_user_data(source_root, target_root, selected_names)`。
-  - 支持文件迁移、文件夹迁移、JSON-only 迁移、战斗方案 UUID 合并。
+  - 支持整文件覆盖、整目录替换、普通文件夹合并和 UUID JSON 合并。
+  - 战斗方案、微调方案、任务序列均按 UUID 合并，避免旧配置覆盖新版内置方案。
 
 - [x] 改造 `function/core/qmw_settings_migrator.py`
   - UI 迁移器复用无 UI 迁移核心。
@@ -179,37 +180,104 @@ PR merge commit = main 上形如 “Merge pull request #927 ...” 的双 parent
 
 ## 迁移规则现状
 
-当前已经覆盖：
+迁移系统采用白名单规则。只有本节列出的用户数据会进入新版 staging；其余版本区文件会随旧版本进入 `backups/`，不会自动进入新版。
+
+### 整文件覆盖
+
+这些文件以来源 FAA 为准，直接覆盖目标 FAA 的同路径文件：
 
 - [x] `config/settings.json`
-- [x] `config/opt_main.json`
+  - 兼容旧路径：`config/opt_main.json`
+  - 该文件仍是整文件覆盖；启动时再由模板补全缺失字段和修正类型。
 - [x] `config/stage_plan.json`
-- [x] `config/cus_images/用户自截/*`
-- [x] `resource/image/common/用户自截/*` 的旧路径兼容
-- [x] `battle_plan/**`
-- [x] `battle_plan_not_active/**`
+- [x] `config/stage_info_extra.json`
+
+### UI 分组
+
+配置迁移工具 UI 使用 `QGroupBox` 分为四组：
+
+- `配置文件`
+  - `配置文件 - 核心`
+  - `配置文件 - 关卡全局方案`
+  - `配置文件 - 自定义关卡信息`
+- `用户自定义图像`
+  - `用户自截`
+  - `背包道具 - 需删除`
+  - `背包装备 - 需使用`
+- `方案与任务`
+  - `战斗方案`
+  - `微调方案`
+  - `自定义任务序列`
+- `其他用户数据`
+  - `公会管理器数据`
+  - `战斗方案 - 未激活`
+
+### 整目录替换
+
+这些目录以来源 FAA 为准。每个目录独立显示为一个迁移选项；迁移前先清空目标目录，再完整复制来源目录：
+
+- [x] `config/cus_images/用户自截/`
+  - 兼容旧路径：`resource/image/common/用户自截/`
+- [x] `config/cus_images/背包_道具_需删除的/`
+- [x] `config/cus_images/背包_装备_需使用的/`
+
+整目录替换只在来源目录存在时执行；来源目录不存在时不会清空目标目录。
+
+### UUID JSON 合并
+
+常用迁移项按以下顺序展示，并按 UUID 合并，不再按文件名覆盖：
+
+- [x] `battle_plan/`
+- [x] `tweak_plan/`
+- [x] `task_sequence/`
+
+其他迁移项放入 `其他用户数据` 分组：
+
+- [x] `battle_plan_not_active/`
+
+通用规则：
+
+- 同 UUID：不迁移来源文件，保留目标 FAA 原文件。
+- 默认 UUID：不迁移，保留目标 FAA 内置方案。
+- UUID 不同但文件名相同：迁移来源文件，并在文件名后追加 ` (1)`、` (2)` 等数字，保留两者。
+- 来源文件缺少 UUID：按对应类型的现有 UUID 生成逻辑生成新 UUID，再迁移。
+- 来源目录内部 UUID 撞车：第一个合法文件保留原 UUID；后续同 UUID 文件生成新 UUID 后迁移。
+- 来源 JSON 损坏或结构无法识别：不迁移，并在迁移报告中记录。
+- 目标 JSON 损坏：不作为有效 UUID 参与去重，不主动删除。
+
+UUID 读取位置：
+
+- 战斗方案：`meta_data.uuid`，兼容旧版顶层 `uuid`。
+- 微调方案：`meta_data.uuid`。
+- 任务序列：第一项的 `meta_data.uuid`。
+
+### 普通文件夹合并
+
 - [x] `logs/guild_manager/**`
-- [x] `task_sequence/**` 的 JSON-only 复制
+  - 用于保留公会管理器数据。
+  - 当前仍是普通合并复制，不清空目标目录。
+
+### 暂不迁移
+
+以下内容暂不进入迁移白名单：
+
+- [x] `resource/db/tasks.db`
+- [x] `cus_extension_addon_script/**`
+- [x] 扩展插件产生的用户数据
+- [x] `logs/` 下除 `logs/guild_manager/**` 外的日志、截图、录屏、识别失败样本和统计产物
+- [x] `.git/`、`.venv/`、`backups/`、`update_cache/` 等更新保留区或开发目录
 
 仍需细化：
 
-- [ ] `tweak_plan/**` 是否属于用户数据。
-- [ ] 自定义识图脚本 / 扩展插件产生的用户数据应迁移哪些路径。
-- [ ] 其他用户手动创建的本地配置或数据目录是否需要白名单。
-- [ ] `task_sequence` 应改为 UUID 合并，不能只按文件名覆盖。
-- [ ] 明确哪些默认 UUID 永远不迁移。
-- [ ] 明确哪些文件只在目标不存在时复制。
-- [ ] 明确哪些文件允许覆盖。
-- [ ] 明确哪些文件只备份不迁移。
-- [ ] 明确哪些文件永远不迁移，例如 `.git`、`.venv`、大体积临时日志。
-- [ ] 迁移前生成更详细的迁移计划，列出复制、覆盖、跳过、合并。
+- [ ] `settings.json` 后续是否升级为字段级迁移，避免旧整文件覆盖新版默认配置。
+- [ ] 迁移后生成更详细的引用校验报告，检查 `stage_plan`、`task_sequence` 引用的战斗方案 / 微调方案 UUID 是否存在。
 - [ ] 更新流程是否允许用户在更新前勾选迁移内容，待定。
 
 ## 已知风险
 
 - [ ] 迁移清单不完整导致用户数据没有进入新版 staging。
-- [ ] 旧用户配置覆盖新版内置配置，导致新版功能异常。
-- [ ] `task_sequence` 按文件名覆盖，可能覆盖新版内置任务。
+- [ ] `settings.json` 整文件覆盖可能覆盖新版默认配置。
+- [x] `task_sequence` 按文件名覆盖，可能覆盖新版内置任务。
 - [ ] 仓库合并策略变化后，PR merge commit 不再稳定存在。
 - [ ] GitHub 网络质量不稳定，刷新列表或下载 archive 可能失败。
 - [ ] 当前更新流程还缺少完整端到端人工演练。

--- a/function/core/qmw_settings_migrator.py
+++ b/function/core/qmw_settings_migrator.py
@@ -6,7 +6,7 @@ from function.globals.loadings import loading
 loading.update_progress(65,"正在加载FAA迁移工具...")
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import QMainWindow, QPushButton, QLabel, QVBoxLayout, QWidget, QMessageBox, \
-    QFileDialog, QHBoxLayout, QCheckBox
+    QFileDialog, QHBoxLayout, QCheckBox, QGroupBox
 
 from function.globals.get_paths import PATHS
 from function.core.settings_migration import build_migration_plan, get_migration_configs, migrate_user_data
@@ -19,7 +19,7 @@ class QMWSettingsMigrator(QMainWindow):
         self.setWindowIcon(QIcon(os.path.join(PATHS["logo"], '圆角-FetDeathWing-450x.png')))
 
         # 设定窗口初始大小 否则将无法自动对齐到上级窗口中心
-        self.resize(1025, 435)
+        self.resize(1025, 560)
 
         self.configs = get_migration_configs()
         self.init_ui()
@@ -32,12 +32,12 @@ class QMWSettingsMigrator(QMainWindow):
         self.setCentralWidget(central_widget)
 
         # 按钮1：选择目标配置
-        self.btn_select_target = QPushButton("选择目标配置")
+        self.btn_select_target = QPushButton("选择目标FAA (会将此处FAA的配置文件迁移到本FAA中)")
         self.btn_select_target.clicked.connect(self.select_target_folder)
         layout_central.addWidget(self.btn_select_target)
 
         # 按钮2：开始迁移配置
-        self.btn_start_migration = QPushButton("开始迁移配置")
+        self.btn_start_migration = QPushButton("开始迁移")
         self.btn_start_migration.setEnabled(False)
         self.btn_start_migration.clicked.connect(self.start_migration)
         layout_central.addWidget(self.btn_start_migration)
@@ -46,9 +46,18 @@ class QMWSettingsMigrator(QMainWindow):
         self.widgets_checkbox = {}
         self.widgets_label = {}
 
+        group_layouts = {}
         for config in self.configs:
+            group_name = config.get("group", "其他")
+            if group_name not in group_layouts:
+                group_box = QGroupBox(group_name)
+                group_layout = QVBoxLayout()
+                group_box.setLayout(group_layout)
+                layout_central.addWidget(group_box)
+                group_layouts[group_name] = group_layout
+
             layout_liner = QHBoxLayout()
-            layout_central.addLayout(layout_liner)
+            group_layouts[group_name].addLayout(layout_liner)
 
             checkbox = QCheckBox(config["name"])
             checkbox.setFixedWidth(200)
@@ -59,22 +68,23 @@ class QMWSettingsMigrator(QMainWindow):
             if config["type"] == "folder":
                 checkbox.setToolTip(
                     "文件夹迁移\n"
-                    "将会**覆盖**当前配置中的同名文件夹!"
+                    "将来源文件夹内容合并到当前 FAA 的同名文件夹。"
                 )
 
-            if config["type"] == "folder_json_only":
+            if config["type"] == "folder_replace":
                 checkbox.setToolTip(
-                    "文件夹迁移\n"
-                    "仅迁移.json文件\n"
-                    "将**覆盖**当前配置中的同名文件夹!\n"
-                    "如需保留FAA更新的内置方案不被旧方案取代, 请手动复制粘贴迁移,并重启FAA"
+                    "整目录替换\n"
+                    "迁移前会先清空当前 FAA 的目标文件夹，再完整复制来源文件夹。\n"
+                    "适用于用户自截、背包删除/使用图片等以用户数据为准的目录。"
                 )
 
-            if config["type"] == "folder_battle_plan":
+            if config["type"] == "folder_uuid_json":
                 # 鼠标提示
                 checkbox.setToolTip(
-                    "战斗方案迁移 会直接覆盖同uuid的所有方案!\n"
-                    "如果方案没有uuid, 则不会被复制!"
+                    "UUID 合并迁移\n"
+                    "同 UUID 文件不迁移，保留当前 FAA 原文件。\n"
+                    "UUID 不同但文件名相同会自动追加括号数字。\n"
+                    "缺少 UUID 的文件会生成新 UUID；损坏 JSON 不迁移。"
                 )
 
             label = QLabel("")
@@ -106,12 +116,7 @@ class QMWSettingsMigrator(QMainWindow):
             checkbox.setEnabled(False)
             checkbox.setChecked(False)
 
-            self.widgets_label[config["name"]].setText(
-                "从: {}\n到: {}".format(
-                    config.get("path_from", "未找到"),
-                    config.get("path_to", "未找到")
-                )
-            )
+            self.widgets_label[config["name"]].setText(self.format_config_paths(config))
 
             # from 找到了 解锁对应ui
             if config.get("available"):
@@ -156,3 +161,10 @@ class QMWSettingsMigrator(QMainWindow):
             self,
             "完成迁移全部!",
             "迁移已完成, 请不要保存配置, 直接重启FAA即可正确应用~")
+
+    @staticmethod
+    def format_config_paths(config: dict) -> str:
+        return "从: {}\n到: {}".format(
+            config.get("path_from", "未找到"),
+            config.get("path_to", "未找到")
+        )

--- a/function/core/settings_migration.py
+++ b/function/core/settings_migration.py
@@ -1,6 +1,8 @@
 import copy
 import json
 import shutil
+import time
+import uuid
 from pathlib import Path
 from typing import Iterable
 
@@ -15,6 +17,7 @@ DEFAULT_UUIDS = {
 MIGRATION_CONFIGS = [
     {
         "name": "配置文件 - 核心",
+        "group": "配置文件",
         "type": "file",
         "locations": [
             Path("config") / "settings.json",
@@ -23,63 +26,88 @@ MIGRATION_CONFIGS = [
     },
     {
         "name": "配置文件 - 关卡全局方案",
+        "group": "配置文件",
         "type": "file",
         "locations": [
             Path("config") / "stage_plan.json",
         ],
     },
     {
-        "name": "用户自截 - 空间服登录界面_1P",
+        "name": "配置文件 - 自定义关卡信息",
+        "group": "配置文件",
         "type": "file",
         "locations": [
-            Path("config") / "cus_images" / "用户自截" / "空间服登录界面_1P.png",
-            Path("resource") / "image" / "common" / "用户自截" / "空间服登录界面_1P.png",
+            Path("config") / "stage_info_extra.json",
         ],
     },
     {
-        "name": "用户自截 - 空间服登录界面_2P",
-        "type": "file",
+        "name": "用户自截",
+        "group": "用户自定义图像",
+        "type": "folder_replace",
         "locations": [
-            Path("config") / "cus_images" / "用户自截" / "空间服登录界面_2P.png",
-            Path("resource") / "image" / "common" / "用户自截" / "空间服登录界面_2P.png",
+            Path("config") / "cus_images" / "用户自截",
+            Path("resource") / "image" / "common" / "用户自截",
+        ],
+        "target_location": Path("config") / "cus_images" / "用户自截",
+    },
+    {
+        "name": "背包道具 - 需删除",
+        "group": "用户自定义图像",
+        "type": "folder_replace",
+        "locations": [
+            Path("config") / "cus_images" / "背包_道具_需删除的",
         ],
     },
     {
-        "name": "用户自截 - 跨服远征_1P",
-        "type": "file",
+        "name": "背包装备 - 需使用",
+        "group": "用户自定义图像",
+        "type": "folder_replace",
         "locations": [
-            Path("config") / "cus_images" / "用户自截" / "跨服远征_1p.png",
-            Path("config") / "cus_images" / "用户自截" / "跨服远征_1P.png",
-            Path("resource") / "image" / "common" / "用户自截" / "跨服远征_1p.png",
-            Path("resource") / "image" / "common" / "用户自截" / "跨服远征_1P.png",
+            Path("config") / "cus_images" / "背包_装备_需使用的",
         ],
     },
     {
         "name": "战斗方案",
-        "type": "folder_battle_plan",
+        "group": "方案与任务",
+        "type": "folder_uuid_json",
+        "uuid_kind": "dict_meta",
         "locations": [
             Path("battle_plan"),
         ],
     },
     {
-        "name": "战斗方案 - 未激活",
-        "type": "folder_battle_plan",
+        "name": "微调方案",
+        "group": "方案与任务",
+        "type": "folder_uuid_json",
+        "uuid_kind": "dict_meta",
         "locations": [
-            Path("battle_plan_not_active"),
+            Path("tweak_plan"),
+        ],
+    },
+    {
+        "name": "自定义任务序列",
+        "group": "方案与任务",
+        "type": "folder_uuid_json",
+        "uuid_kind": "task_sequence",
+        "locations": [
+            Path("task_sequence"),
         ],
     },
     {
         "name": "公会管理器数据",
+        "group": "其他用户数据",
         "type": "folder",
         "locations": [
             Path("logs") / "guild_manager",
         ],
     },
     {
-        "name": "自定义任务序列",
-        "type": "folder_json_only",
+        "name": "战斗方案 - 未激活",
+        "group": "其他用户数据",
+        "type": "folder_uuid_json",
+        "uuid_kind": "dict_meta",
         "locations": [
-            Path("task_sequence"),
+            Path("battle_plan_not_active"),
         ],
     },
 ]
@@ -107,6 +135,15 @@ def find_target_path(root: Path, locations: list[Path], allow_missing_target: bo
     return None
 
 
+def resolve_config_locations(config: dict) -> tuple[list[Path], list[Path]]:
+    locations = [Path(location) for location in config["locations"]]
+    if config.get("target_location"):
+        target_locations = [Path(config["target_location"])]
+    else:
+        target_locations = locations
+    return locations, target_locations
+
+
 def build_migration_plan(
     source_root: Path,
     target_root: Path,
@@ -118,10 +155,11 @@ def build_migration_plan(
     plan = []
 
     for config in get_migration_configs() if configs is None else copy.deepcopy(configs):
-        locations = [Path(location) for location in config["locations"]]
+        locations, target_locations = resolve_config_locations(config)
         path_from = find_source_path(source_root, locations)
-        path_to = find_target_path(target_root, locations, allow_missing_target)
+        path_to = find_target_path(target_root, target_locations, allow_missing_target)
         config["locations"] = locations
+        config["target_locations"] = target_locations
         config["path_from"] = path_from
         config["path_to"] = path_to
         config["available"] = path_from is not None and path_to is not None
@@ -130,47 +168,206 @@ def build_migration_plan(
     return plan
 
 
-def read_uuid(path: Path) -> str | None:
+def generate_uuid() -> str:
+    value = str(uuid.uuid1())
+    time.sleep(0.001)
+    return value
+
+
+def read_json(path: Path):
     with path.open(mode="r", encoding="utf-8") as file:
-        data = json.load(file)
-
-    uuid = data.get("uuid")
-    if not uuid:
-        uuid = data.get("meta_data", {}).get("uuid")
-    if uuid in DEFAULT_UUIDS:
-        return None
-    return uuid
+        return json.load(file)
 
 
-def process_json_files_by_uuid(folder_from: Path, folder_to: Path) -> None:
-    folder_to.mkdir(parents=True, exist_ok=True)
+def is_legacy_battle_plan(data) -> bool:
+    return isinstance(data, dict) and "card" in data and ("player" in data or "uuid" in data)
 
-    source_uuids = {}
-    for file_path in folder_from.glob("*.json"):
-        uuid = read_uuid(file_path)
-        if uuid:
-            source_uuids[uuid] = file_path
 
+def ensure_dict_meta_uuid(data) -> tuple[str, bool, str]:
+    if not isinstance(data, dict):
+        raise ValueError("JSON root is not an object.")
+
+    meta_data = data.get("meta_data")
+    if isinstance(meta_data, dict) and meta_data.get("uuid"):
+        return meta_data["uuid"], False, "meta_data"
+
+    if data.get("uuid"):
+        return data["uuid"], False, "uuid"
+
+    new_uuid = generate_uuid()
+    if is_legacy_battle_plan(data):
+        data["uuid"] = new_uuid
+        return new_uuid, True, "uuid"
+
+    if not isinstance(meta_data, dict):
+        meta_data = {}
+        data["meta_data"] = meta_data
+    meta_data["uuid"] = new_uuid
+    return new_uuid, True, "meta_data"
+
+
+def set_dict_meta_uuid(data, new_uuid: str, uuid_location: str) -> None:
+    if uuid_location == "uuid":
+        data["uuid"] = new_uuid
+        return
+    meta_data = data.setdefault("meta_data", {})
+    meta_data["uuid"] = new_uuid
+
+
+def ensure_task_sequence_uuid(data) -> tuple[str, bool, str]:
+    if not isinstance(data, list):
+        raise ValueError("Task sequence JSON root is not a list.")
+    if data and not isinstance(data[0], dict):
+        raise ValueError("Task sequence first item is not an object.")
+
+    if data and isinstance(data[0].get("meta_data"), dict) and data[0]["meta_data"].get("uuid"):
+        return data[0]["meta_data"]["uuid"], False, "task_sequence"
+
+    new_uuid = generate_uuid()
+    meta_item = {
+        "meta_data": {
+            "uuid": new_uuid,
+            "version": "1.0",
+        }
+    }
+    if data and "meta_data" in data[0]:
+        data[0]["meta_data"] = meta_item["meta_data"]
+    else:
+        data.insert(0, meta_item)
+    return new_uuid, True, "task_sequence"
+
+
+def set_task_sequence_uuid(data, new_uuid: str, _uuid_location: str) -> None:
+    if not data or not isinstance(data[0], dict):
+        data.insert(0, {"meta_data": {"uuid": new_uuid, "version": "1.0"}})
+        return
+    meta_data = data[0].setdefault("meta_data", {})
+    meta_data["uuid"] = new_uuid
+
+
+UUID_HANDLERS = {
+    "dict_meta": (ensure_dict_meta_uuid, set_dict_meta_uuid),
+    "task_sequence": (ensure_task_sequence_uuid, set_task_sequence_uuid),
+}
+
+
+def read_uuid_json(path: Path, uuid_kind: str) -> tuple[object, str, bool, str]:
+    data = read_json(path)
+    ensure_uuid, _set_uuid = UUID_HANDLERS[uuid_kind]
+    uuid_value, changed, uuid_location = ensure_uuid(data)
+    return data, uuid_value, changed, uuid_location
+
+
+def collect_target_uuids(folder_to: Path, uuid_kind: str) -> dict[str, Path]:
     target_uuids = {}
-    for file_path in folder_to.glob("*.json"):
-        uuid = read_uuid(file_path)
-        if uuid:
-            target_uuids[uuid] = file_path
+    if not folder_to.is_dir():
+        return target_uuids
 
-    common_uuids = set(source_uuids) & set(target_uuids)
-    source_only_uuids = set(source_uuids) - set(target_uuids)
+    for file_path in sorted(folder_to.glob("*.json"), key=lambda path: path.name.lower()):
+        try:
+            _data, uuid_value, _changed, _uuid_location = read_uuid_json(file_path, uuid_kind)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError, KeyError, TypeError):
+            continue
+        if uuid_value and uuid_value not in target_uuids:
+            target_uuids[uuid_value] = file_path
+    return target_uuids
 
-    for uuid in common_uuids:
-        with source_uuids[uuid].open(mode="r", encoding="utf-8") as file:
-            data = json.load(file)
-        with target_uuids[uuid].open(mode="w", encoding="utf-8") as file:
-            json.dump(data, file, ensure_ascii=False, indent=4)
 
-    for uuid in source_only_uuids:
-        shutil.copy2(source_uuids[uuid], folder_to / source_uuids[uuid].name)
+def unique_destination_path(folder_to: Path, file_name: str) -> Path:
+    candidate = folder_to / file_name
+    if not candidate.exists():
+        return candidate
+
+    stem = candidate.stem
+    suffix = candidate.suffix
+    index = 1
+    while True:
+        candidate = folder_to / f"{stem} ({index}){suffix}"
+        if not candidate.exists():
+            return candidate
+        index += 1
+
+
+def write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open(mode="w", encoding="utf-8") as file:
+        json.dump(data, file, ensure_ascii=False, indent=4)
+        file.write("\n")
+
+
+def replace_folder(folder_from: Path, folder_to: Path) -> dict:
+    if folder_to.exists():
+        if folder_to.is_dir():
+            shutil.rmtree(folder_to)
+        else:
+            folder_to.unlink()
+    shutil.copytree(folder_from, folder_to)
+    return {"operation": "replace_folder", "from": str(folder_from), "to": str(folder_to)}
+
+
+def process_uuid_json_folder(folder_from: Path, folder_to: Path, uuid_kind: str) -> dict:
+    folder_to.mkdir(parents=True, exist_ok=True)
+    _ensure_uuid, set_uuid = UUID_HANDLERS[uuid_kind]
+    target_uuids = collect_target_uuids(folder_to, uuid_kind)
+    source_seen_uuids = set()
+    items = []
+
+    for source_path in sorted(folder_from.glob("*.json"), key=lambda path: path.name.lower()):
+        item = {
+            "source": str(source_path),
+            "target": "",
+            "uuid": "",
+            "status": "",
+            "reason": "",
+        }
+        try:
+            data, uuid_value, generated_missing_uuid, uuid_location = read_uuid_json(source_path, uuid_kind)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError, KeyError, TypeError) as exc:
+            item["status"] = "invalid_json"
+            item["reason"] = str(exc) or exc.__class__.__name__
+            items.append(item)
+            continue
+
+        item["uuid"] = uuid_value
+        if uuid_value in DEFAULT_UUIDS:
+            item["status"] = "skipped_default_uuid"
+            item["reason"] = "默认 UUID 不迁移，保留目标 FAA 内置方案。"
+            items.append(item)
+            continue
+
+        if uuid_value in source_seen_uuids:
+            old_uuid = uuid_value
+            uuid_value = generate_uuid()
+            set_uuid(data, uuid_value, uuid_location)
+            item["uuid"] = uuid_value
+            item["reason"] = f"源目录内 UUID {old_uuid} 撞车，已生成新 UUID。"
+        elif uuid_value in target_uuids:
+            source_seen_uuids.add(uuid_value)
+            item["target"] = str(target_uuids[uuid_value])
+            item["status"] = "skipped_same_uuid"
+            item["reason"] = "目标 FAA 已存在同 UUID，按规则保留目标文件。"
+            items.append(item)
+            continue
+        elif generated_missing_uuid:
+            item["reason"] = "源文件缺少 UUID，已生成新 UUID。"
+
+        source_seen_uuids.add(uuid_value)
+        destination = unique_destination_path(folder_to, source_path.name)
+        write_json(destination, data)
+        target_uuids[uuid_value] = destination
+        item["target"] = str(destination)
+        item["status"] = "migrated"
+        items.append(item)
+
+    summary = {}
+    for item in items:
+        summary[item["status"]] = summary.get(item["status"], 0) + 1
+    return {"operation": "uuid_json_folder", "uuid_kind": uuid_kind, "items": items, "summary": summary}
 
 
 def migrate_one(config: dict) -> bool:
+    migration_type = config["type"]
+
     path_from = config.get("path_from")
     path_to = config.get("path_to")
 
@@ -179,26 +376,24 @@ def migrate_one(config: dict) -> bool:
 
     path_from = Path(path_from)
     path_to = Path(path_to)
-    migration_type = config["type"]
 
     if migration_type == "file":
         path_to.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(path_from, path_to)
+        config["detail"] = {"operation": "copy_file", "from": str(path_from), "to": str(path_to)}
         return True
 
     if migration_type == "folder":
         shutil.copytree(path_from, path_to, dirs_exist_ok=True)
+        config["detail"] = {"operation": "merge_folder", "from": str(path_from), "to": str(path_to)}
         return True
 
-    if migration_type == "folder_json_only":
-        def ignore_non_json_files(_dir, files):
-            return [file for file in files if not file.endswith(".json")]
-
-        shutil.copytree(path_from, path_to, dirs_exist_ok=True, ignore=ignore_non_json_files)
+    if migration_type == "folder_replace":
+        config["detail"] = replace_folder(path_from, path_to)
         return True
 
-    if migration_type == "folder_battle_plan":
-        process_json_files_by_uuid(path_from, path_to)
+    if migration_type == "folder_uuid_json":
+        config["detail"] = process_uuid_json_folder(path_from, path_to, config.get("uuid_kind", "dict_meta"))
         return True
 
     raise ValueError(f"Unsupported migration type: {migration_type}")

--- a/function/core/update_prepare.py
+++ b/function/core/update_prepare.py
@@ -17,23 +17,26 @@ from function.core.settings_migration import migrate_user_data
 MIGRATION_REPORT_RELATIVE_PATH = Path("update_cache") / "migration_report.json"
 
 
+def to_json_serializable(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {key: to_json_serializable(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [to_json_serializable(item) for item in value]
+    if isinstance(value, tuple):
+        return [to_json_serializable(item) for item in value]
+    return value
+
+
 def write_migration_report(staging_root: Path, results: list[dict[str, Any]]) -> Path:
     report_path = staging_root / MIGRATION_REPORT_RELATIVE_PATH
     report_path.parent.mkdir(parents=True, exist_ok=True)
 
-    serializable_results = []
-    for item in results:
-        copied = dict(item)
-        for key in ("path_from", "path_to"):
-            if copied.get(key) is not None:
-                copied[key] = str(copied[key])
-        copied["locations"] = [str(location) for location in copied.get("locations", [])]
-        serializable_results.append(copied)
-
     report = {
         "schema_version": 1,
         "created_at": datetime.now(timezone.utc).isoformat(),
-        "results": serializable_results,
+        "results": to_json_serializable(results),
         "summary": summarize_migration_results(results),
     }
     report_path.write_text(json.dumps(report, ensure_ascii=False, indent=4) + "\n", encoding="utf-8")

--- a/test/test_settings_migration.py
+++ b/test/test_settings_migration.py
@@ -1,0 +1,185 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from function.core.settings_migration import DEFAULT_UUIDS, get_migration_configs, migrate_one
+from function.core.update_prepare import write_migration_report
+
+
+def write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=4), encoding="utf-8")
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class SettingsMigrationTest(unittest.TestCase):
+    def test_default_migration_config_order(self):
+        names = [config["name"] for config in get_migration_configs()]
+
+        self.assertEqual(
+            names,
+            [
+                "配置文件 - 核心",
+                "配置文件 - 关卡全局方案",
+                "配置文件 - 自定义关卡信息",
+                "用户自截",
+                "背包道具 - 需删除",
+                "背包装备 - 需使用",
+                "战斗方案",
+                "微调方案",
+                "自定义任务序列",
+                "公会管理器数据",
+                "战斗方案 - 未激活",
+            ],
+        )
+
+        self.assertEqual(
+            [config["group"] for config in get_migration_configs()],
+            [
+                "配置文件",
+                "配置文件",
+                "配置文件",
+                "用户自定义图像",
+                "用户自定义图像",
+                "用户自定义图像",
+                "方案与任务",
+                "方案与任务",
+                "方案与任务",
+                "其他用户数据",
+                "其他用户数据",
+            ],
+        )
+
+    def test_uuid_json_folder_keeps_target_same_uuid_and_renames_same_name(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source" / "battle_plan"
+            target = root / "target" / "battle_plan"
+
+            keep_uuid = "11111111-1111-1111-1111-111111111111"
+            target_name_uuid = "22222222-2222-2222-2222-222222222222"
+            source_name_uuid = "33333333-3333-3333-3333-333333333333"
+            duplicated_uuid = "44444444-4444-4444-4444-444444444444"
+
+            write_json(target / "Keep.json", {"meta_data": {"uuid": keep_uuid}, "value": "target"})
+            write_json(target / "SameName.json", {"meta_data": {"uuid": target_name_uuid}, "value": "target"})
+
+            write_json(source / "KeepSource.json", {"meta_data": {"uuid": keep_uuid}, "value": "source"})
+            write_json(source / "KeepSourceCopy.json", {"meta_data": {"uuid": keep_uuid}, "value": "source_copy"})
+            write_json(source / "SameName.json", {"meta_data": {"uuid": source_name_uuid}, "value": "source"})
+            write_json(source / "MissingUuid.json", {"meta_data": {"version": "3.0"}, "value": "missing_uuid"})
+            write_json(source / "DupA.json", {"meta_data": {"uuid": duplicated_uuid}, "value": "dup_a"})
+            write_json(source / "DupB.json", {"meta_data": {"uuid": duplicated_uuid}, "value": "dup_b"})
+            write_json(source / "DefaultUuid.json", {"meta_data": {"uuid": next(iter(DEFAULT_UUIDS))}})
+            (source / "Broken.json").write_text("{broken", encoding="utf-8")
+
+            config = {
+                "name": "战斗方案",
+                "type": "folder_uuid_json",
+                "uuid_kind": "dict_meta",
+                "path_from": source,
+                "path_to": target,
+            }
+
+            self.assertTrue(migrate_one(config))
+
+            self.assertEqual(read_json(target / "Keep.json")["value"], "target")
+            self.assertNotEqual(read_json(target / "KeepSourceCopy.json")["meta_data"]["uuid"], keep_uuid)
+            self.assertEqual(read_json(target / "KeepSourceCopy.json")["value"], "source_copy")
+            self.assertEqual(read_json(target / "SameName.json")["meta_data"]["uuid"], target_name_uuid)
+            self.assertEqual(read_json(target / "SameName (1).json")["meta_data"]["uuid"], source_name_uuid)
+            self.assertTrue((target / "MissingUuid.json").is_file())
+            self.assertTrue(read_json(target / "MissingUuid.json")["meta_data"]["uuid"])
+            self.assertEqual(read_json(target / "DupA.json")["meta_data"]["uuid"], duplicated_uuid)
+            self.assertNotEqual(read_json(target / "DupB.json")["meta_data"]["uuid"], duplicated_uuid)
+            self.assertFalse((target / "Broken.json").exists())
+            self.assertFalse((target / "DefaultUuid.json").exists())
+
+            summary = config["detail"]["summary"]
+            self.assertEqual(summary["migrated"], 5)
+            self.assertEqual(summary["skipped_same_uuid"], 1)
+            self.assertEqual(summary["skipped_default_uuid"], 1)
+            self.assertEqual(summary["invalid_json"], 1)
+
+    def test_task_sequence_uuid_folder_inserts_missing_meta_data(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source" / "task_sequence"
+            target = root / "target" / "task_sequence"
+
+            keep_uuid = "55555555-5555-5555-5555-555555555555"
+            write_json(target / "Keep.json", [{"meta_data": {"uuid": keep_uuid}}, {"task": "target"}])
+            write_json(source / "KeepSource.json", [{"meta_data": {"uuid": keep_uuid}}, {"task": "source"}])
+            write_json(source / "NoMeta.json", [{"task": "source"}])
+
+            config = {
+                "name": "自定义任务序列",
+                "type": "folder_uuid_json",
+                "uuid_kind": "task_sequence",
+                "path_from": source,
+                "path_to": target,
+            }
+
+            self.assertTrue(migrate_one(config))
+
+            self.assertEqual(read_json(target / "Keep.json")[1]["task"], "target")
+            migrated = read_json(target / "NoMeta.json")
+            self.assertIn("meta_data", migrated[0])
+            self.assertTrue(migrated[0]["meta_data"]["uuid"])
+            self.assertEqual(migrated[1]["task"], "source")
+
+    def test_folder_replace_removes_existing_target_content(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source" / "config" / "cus_images" / "用户自截"
+            target = root / "target" / "config" / "cus_images" / "用户自截"
+            source.mkdir(parents=True)
+            target.mkdir(parents=True)
+            (source / "new.png").write_text("new", encoding="utf-8")
+            (target / "old.png").write_text("old", encoding="utf-8")
+
+            config = {
+                "name": "用户自截",
+                "type": "folder_replace",
+                "path_from": source,
+                "path_to": target,
+            }
+
+            self.assertTrue(migrate_one(config))
+            self.assertTrue((target / "new.png").is_file())
+            self.assertFalse((target / "old.png").exists())
+
+    def test_write_migration_report_serializes_paths_recursively(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            staging_root = Path(temp_dir)
+            report_path = write_migration_report(
+                staging_root,
+                [
+                    {
+                        "name": "用户自截",
+                        "status": "migrated",
+                        "locations": [Path("config") / "cus_images" / "用户自截"],
+                        "target_locations": [Path("config") / "cus_images" / "用户自截"],
+                        "path_from": staging_root / "source",
+                        "path_to": staging_root / "target",
+                        "detail": {
+                            "operation": "replace_folder",
+                            "paths": [staging_root / "target" / "new.png"],
+                        },
+                    }
+                ],
+            )
+
+            report = read_json(report_path)
+            result = report["results"][0]
+            self.assertEqual(result["locations"], [str(Path("config") / "cus_images" / "用户自截")])
+            self.assertEqual(result["target_locations"], [str(Path("config") / "cus_images" / "用户自截")])
+            self.assertEqual(result["detail"]["paths"], [str(staging_root / "target" / "new.png")])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* 完善配置迁移白名单，补充自定义关卡信息、用户图像目录、微调方案和任务序列迁移规则。
* 战斗方案、微调方案、任务序列改为 UUID 合并，避免旧文件覆盖新版内置内容。
* 配置迁移工具按数据类型分组展示，并补充迁移报告序列化与专项测试。