### PR TITLE
fix(热更新): 改为按开发工作区阻止更新

### DIFF
--- a/function/common/update_staging.py
+++ b/function/common/update_staging.py
@@ -300,7 +300,6 @@ def build_staging_state(target: dict[str, Any]) -> dict[str, Any]:
         "version": version,
         "tag": tag,
         "commit": commit,
-        "branch": target.get("branch", "main"),
         "pr": target.get("pr"),
         "summary": target.get("summary") or target.get("title", ""),
         "title": target.get("title", ""),

--- a/function/common/update_state.py
+++ b/function/common/update_state.py
@@ -70,7 +70,6 @@ def get_git_state(project_root: Path) -> dict[str, Any]:
     if not is_git_worktree_root(project_root):
         return {
             "commit": "",
-            "branch": "",
             "tag": "",
             "pr": None,
             "summary": "",
@@ -78,14 +77,12 @@ def get_git_state(project_root: Path) -> dict[str, Any]:
         }
 
     commit = run_git(project_root, ["rev-parse", "HEAD"])
-    branch = run_git(project_root, ["rev-parse", "--abbrev-ref", "HEAD"])
     tag = run_git(project_root, ["describe", "--tags", "--exact-match", "HEAD"])
     message = run_git(project_root, ["log", "-1", "--pretty=%B"])
     dirty = bool(run_git(project_root, ["status", "--porcelain"]))
 
     return {
         "commit": commit,
-        "branch": branch,
         "tag": tag,
         "pr": parse_pr_number(message),
         "summary": next((line for line in message.splitlines() if line.strip()), ""),
@@ -103,7 +100,6 @@ def build_update_state(project_root: Path, timestamp_key: str = "packaged_at") -
         "version": version,
         "tag": git_state["tag"],
         "commit": git_state["commit"],
-        "branch": git_state["branch"],
         "pr": git_state["pr"],
         "summary": git_state["summary"],
         "merged_at": "",
@@ -170,7 +166,6 @@ def detect_local_state(project_root: Path) -> dict[str, Any]:
     if git_state.get("commit"):
         detected["source"] = "git"
         detected["commit"] = git_state["commit"]
-        detected["branch"] = git_state["branch"]
         detected["tag"] = git_state["tag"]
         detected["pr"] = git_state["pr"] or saved_state.get("pr")
         detected["merged_at"] = saved_state.get("merged_at", "")
@@ -180,7 +175,6 @@ def detect_local_state(project_root: Path) -> dict[str, Any]:
     if saved_state:
         detected["source"] = "update_state"
         detected["commit"] = saved_state.get("commit", "")
-        detected["branch"] = saved_state.get("branch", "")
         detected["tag"] = saved_state.get("tag", version)
         detected["pr"] = saved_state.get("pr")
         detected["merged_at"] = saved_state.get("merged_at", "")
@@ -188,7 +182,6 @@ def detect_local_state(project_root: Path) -> dict[str, Any]:
         return detected
 
     detected["commit"] = ""
-    detected["branch"] = ""
     detected["tag"] = ""
     detected["pr"] = None
     detected["merged_at"] = ""

--- a/function/core/qmw_3_service.py
+++ b/function/core/qmw_3_service.py
@@ -434,7 +434,7 @@ class QMainWindowService(QMainWindowLoadSettings):
         self.update_state_labels = {
             "version": self.UpdateVersionInfoLabel,
             "node": self.UpdateNodeInfoLabel,
-            "branch": self.UpdateBranchInfoLabel,
+            "version_type": self.UpdateBranchInfoLabel,
             "source": self.UpdateSourceInfoLabel,
         }
         if hasattr(self, "UpdateStateGridLayout"):
@@ -467,28 +467,19 @@ class QMainWindowService(QMainWindowLoadSettings):
         pr_text = f"#{pr}" if pr else "未记录"
         commit = local_state.get("commit") or ""
         commit_text = commit[:12] if commit else "未记录"
-        branch = local_state.get("branch") or "未记录"
         merged_at = release_entry.get("merged_at") or local_state.get("merged_at") or "未记录"
         return {
-            "version": f"当前版本：{version} {self._format_version_note(version, tag)}",
+            "version": f"当前版本：{version}",
             "node": f"更新节点：PR {pr_text} / {commit_text} / {merged_at}",
-            "branch": f"分支：{self._format_update_branch(branch)}",
+            "version_type": f"版本类型：{self._format_version_type(version, tag)}",
             "source": f"版本信息和当前状态来源：{self._format_update_state_source(local_state)}",
         }
 
     @staticmethod
-    def _format_version_note(version: str, tag: str) -> str:
+    def _format_version_type(version: str, tag: str) -> str:
         if version != "未知" and version == tag:
-            return "（内部版本号与Git Tag一致，为标准发行版）"
-        return "（无GitTag，为中间版本，有可能不稳定的特性）"
-
-    @staticmethod
-    def _format_update_branch(branch: str) -> str:
-        if branch.lower() == "main":
-            return "Main（发行主分支）"
-        if not branch or branch == "未记录":
-            return "未记录（无法确认当前是否为主分支）"
-        return f"{branch}（开发者个人分支 注：本模块请务必在主分支使用）"
+            return "内部版本号与Git Tag一致，为标准发行版"
+        return "无GitTag，为中间版本，有可能不稳定的特性"
 
     @staticmethod
     def _format_update_state_source(local_state: dict) -> str:
@@ -499,21 +490,19 @@ class QMainWindowService(QMainWindowLoadSettings):
             return "用户本地 - 版本状态文件正常运作"
         return "用户本地 - 版本状态文件异常运作，使用项目全局VERSION变量"
 
-    def _ensure_update_allowed_on_main_branch(self) -> bool:
+    def _ensure_update_allowed_outside_git_worktree(self) -> bool:
         local_state = detect_local_state(Path(PATHS["root"]))
-        branch = local_state.get("branch") or ""
-        if branch.lower() == "main":
+        if local_state.get("source") != "git":
             return True
 
-        branch_text = branch or "未记录"
         self.refresh_update_state_label(local_state=local_state)
         message = (
-            f"当前检测到的分支：{branch_text}\n\n"
-            "为避免在开发者个人分支误触热更新并覆盖工作区，本功能只允许在 main 主分支使用。\n"
-            "请切换到 main 分支，或使用标准打包版后再执行更新。"
+            "当前运行目录是真实 Git 开发工作区。\n\n"
+            "为避免热更新覆盖开发者源码工作区，本功能已被阻止。\n"
+            "请先打包为标准发行包，再在打包后的目录中测试热更新。"
         )
-        SIGNAL.PRINT_TO_UI.emit(f"[更新状态] 已阻止非 main 分支执行更新。当前分支：{branch_text}", color_level=1)
-        QMessageBox.warning(self, "当前分支不允许执行更新", message)
+        SIGNAL.PRINT_TO_UI.emit("[更新状态] 已阻止在 Git 开发工作区执行热更新。", color_level=1)
+        QMessageBox.warning(self, "开发者工作区不允许执行更新", message)
         return False
 
     def refresh_update_progress_label(self):
@@ -1628,7 +1617,7 @@ class QMainWindowService(QMainWindowLoadSettings):
 
     def click_btn_normal_update(self):
         """准备并确认应用用户在表格中选中的更新目标。"""
-        if not self._ensure_update_allowed_on_main_branch():
+        if not self._ensure_update_allowed_outside_git_worktree():
             return
 
         target = self._selected_update_target()

--- a/resource/ui/FAA_3.0.ui
+++ b/resource/ui/FAA_3.0.ui
@@ -7263,7 +7263,7 @@ FAA放卡核心原理简述:
                <item row="1" column="0">
                 <widget class="QLabel" name="UpdateBranchInfoLabel">
                  <property name="text">
-                  <string>分支：读取中...</string>
+                  <string>版本类型：读取中...</string>
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>


### PR DESCRIPTION
## 内容
- 去除本地分支字段的记录和判断，避免发行包被 detached HEAD 误判。
- 将检查更新页的“分支”信息替换为“版本类型”。
- 仅在真实 Git 开发工作区阻止热更新，提示开发者打包后测试，避免覆盖源码工作区。

## 校验
- py -3.12 -m py_compile function\common\update_state.py function\common\update_staging.py function\core\qmw_3_service.py
- 验证 update_state / staging 不再包含 branch 字段
- git diff --check