### PR TITLE
perf(热更新): 显示下载进度并完善替换提示

### DIFF
--- a/function/common/update_staging.py
+++ b/function/common/update_staging.py
@@ -7,7 +7,7 @@ import urllib.request
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from function.common.update_manifest import DEFAULT_OWNER, DEFAULT_REPO
 from function.common.update_state import write_update_state
@@ -154,21 +154,72 @@ def download_github_archive(
     owner: str = DEFAULT_OWNER,
     repo: str = DEFAULT_REPO,
     retries: int = 2,
+    progress_callback: Callable[[dict[str, Any]], None] | None = None,
 ) -> Path:
     url = f"https://github.com/{owner}/{repo}/archive/{ref}.zip"
     dest_zip.parent.mkdir(parents=True, exist_ok=True)
     headers = {"User-Agent": "FAA-Updater"}
 
+    def emit_progress(downloaded_bytes: int, total_bytes: int | None, started_at: float) -> None:
+        if progress_callback is None:
+            return
+
+        elapsed_seconds = max(time.monotonic() - started_at, 0.001)
+        speed_bytes_per_second = downloaded_bytes / elapsed_seconds
+        remaining_seconds = None
+        percent = None
+        if total_bytes and total_bytes > 0:
+            percent = min(downloaded_bytes / total_bytes * 100, 100.0)
+            if speed_bytes_per_second > 0:
+                remaining_seconds = max((total_bytes - downloaded_bytes) / speed_bytes_per_second, 0.0)
+
+        progress_callback({
+            "phase": "download",
+            "downloaded_bytes": downloaded_bytes,
+            "total_bytes": total_bytes,
+            "percent": percent,
+            "speed_bytes_per_second": speed_bytes_per_second,
+            "remaining_seconds": remaining_seconds,
+        })
+
     for attempt in range(retries + 1):
         request = urllib.request.Request(url, headers=headers)
+        started_at = time.monotonic()
+        if progress_callback is not None:
+            progress_callback({
+                "phase": "download_connecting",
+                "message": "正在连接 GitHub 源码包下载地址，尚未收到文件大小",
+            })
         try:
             with urllib.request.urlopen(request, timeout=60) as response:
+                total_header = response.headers.get("Content-Length")
+                total_bytes = int(total_header) if total_header and total_header.isdigit() else None
+                downloaded_bytes = 0
+                last_emit_at = 0.0
+                emit_progress(downloaded_bytes, total_bytes, started_at)
                 with dest_zip.open("wb") as file:
-                    shutil.copyfileobj(response, file)
+                    while True:
+                        chunk = response.read(64 * 1024)
+                        if not chunk:
+                            break
+                        file.write(chunk)
+                        downloaded_bytes += len(chunk)
+                        now = time.monotonic()
+                        if now - last_emit_at >= 0.5:
+                            emit_progress(downloaded_bytes, total_bytes, started_at)
+                            last_emit_at = now
+                emit_progress(downloaded_bytes, total_bytes, started_at)
             return dest_zip
         except (http.client.IncompleteRead, urllib.error.URLError, TimeoutError):
+            if dest_zip.exists():
+                dest_zip.unlink()
             if attempt >= retries:
                 raise
+            if progress_callback is not None:
+                progress_callback({
+                    "phase": "download_connecting",
+                    "message": f"GitHub 源码包下载连接失败，正在第 {attempt + 1} 次重试",
+                })
             time.sleep(1.0 * (attempt + 1))
 
     raise StagingError(f"Failed to download GitHub archive: {url}")
@@ -357,6 +408,7 @@ def prepare_staging_from_github(
     target: dict[str, Any],
     owner: str = DEFAULT_OWNER,
     repo: str = DEFAULT_REPO,
+    progress_callback: Callable[[dict[str, Any]], None] | None = None,
 ) -> Path:
     ref = target.get("tag") or target.get("commit")
     if not ref:
@@ -371,7 +423,7 @@ def prepare_staging_from_github(
     archive_root.mkdir(parents=True, exist_ok=True)
 
     try:
-        download_github_archive(ref, archive_path, owner=owner, repo=repo)
+        download_github_archive(ref, archive_path, owner=owner, repo=repo, progress_callback=progress_callback)
         return prepare_staging_from_archive(root, archive_path, target)
     finally:
         if archive_root.exists():

--- a/function/core/git_update_manager.py
+++ b/function/core/git_update_manager.py
@@ -140,6 +140,7 @@ class ReleasePrepareWorker(QThread):
     """Prepare staging for a selected release target."""
 
     result = pyqtSignal(bool, str, dict)
+    progress = pyqtSignal(dict)
 
     def __init__(self, target: dict, parent=None):
         super().__init__(parent)
@@ -148,7 +149,11 @@ class ReleasePrepareWorker(QThread):
     def run(self):
         try:
             root = Path(PATHS["root"])
-            payload = prepare_update_from_github(root, self.target)
+            self.progress.emit({
+                "phase": "prepare",
+                "message": "正在校验目标版本，尚未开始下载",
+            })
+            payload = prepare_update_from_github(root, self.target, progress_callback=self.progress.emit)
             self.result.emit(True, "更新准备完成", payload)
         except Exception as exc:
             CUS_LOGGER.error(f"准备更新失败：{exc}")
@@ -209,9 +214,10 @@ def refresh_release_manifest():
     return worker
 
 
-def prepare_release_update(target: dict):
+def prepare_release_update(target: dict, auto_start: bool = True):
     worker = ReleasePrepareWorker(target=target)
-    worker.start()
+    if auto_start:
+        worker.start()
     return worker
 
 

--- a/function/core/qmw_3_service.py
+++ b/function/core/qmw_3_service.py
@@ -333,6 +333,7 @@ class QMainWindowService(QMainWindowLoadSettings):
         self.refresh_update_state_label()
         self.update_progress_started_at = None
         self.update_progress_step = "空闲"
+        self.update_download_progress = None
         self.update_progress_timer = QtCore.QTimer(self)
         self.update_progress_timer.setInterval(1000)
         self.update_progress_timer.timeout.connect(self.refresh_update_progress_label)
@@ -512,7 +513,50 @@ class QMainWindowService(QMainWindowLoadSettings):
             return
 
         elapsed = int((datetime.datetime.now() - self.update_progress_started_at).total_seconds())
-        self.UpdateProgressLabel.setText(f"更新进度：{self.update_progress_step}，已等待 {elapsed} 秒")
+        progress_detail = self._format_update_download_progress()
+        suffix = f"，{progress_detail}" if progress_detail else ""
+        end = "。" if progress_detail else ""
+        self.UpdateProgressLabel.setText(f"更新进度：{self.update_progress_step}，已等待 {elapsed} 秒{suffix}{end}")
+
+    @staticmethod
+    def _format_update_progress_mb(size_bytes: int | float | None) -> str:
+        if size_bytes is None:
+            return "未知"
+        return f"{float(size_bytes) / 1024 / 1024:.2f}"
+
+    def _format_update_download_progress(self) -> str:
+        """生成下载阶段的体积、百分比、速度和预计剩余时间文本。"""
+        progress = self.update_download_progress
+        if not progress:
+            return ""
+        if progress.get("phase") != "download":
+            return progress.get("message", "")
+
+        downloaded = progress.get("downloaded_bytes") or 0
+        total = progress.get("total_bytes")
+        speed = progress.get("speed_bytes_per_second") or 0
+        speed_text = f"{speed / 1024 / 1024:.2f}MB/s"
+
+        if total:
+            percent = progress.get("percent")
+            percent_text = f"{percent:.1f}%" if percent is not None else "--%"
+            remaining = progress.get("remaining_seconds")
+            remaining_text = f"{int(remaining + 0.5)}秒" if remaining is not None else "未知"
+            return (
+                f"{self._format_update_progress_mb(downloaded)}/"
+                f"{self._format_update_progress_mb(total)} MB，"
+                f"{percent_text}，{speed_text}，预计还需{remaining_text}"
+            )
+
+        return (
+            f"已下载 {self._format_update_progress_mb(downloaded)} MB，{speed_text}，"
+            "Github正在生成下载文件中大小未知"
+        )
+
+    def update_download_progress_detail(self, progress: dict):
+        """接收下载 worker 上报的字节级进度，并刷新更新页进度文本。"""
+        self.update_download_progress = progress
+        self.refresh_update_progress_label()
 
     def start_update_progress(self, step: str):
         """
@@ -523,6 +567,7 @@ class QMainWindowService(QMainWindowLoadSettings):
         """
         self.update_progress_step = step
         self.update_progress_started_at = datetime.datetime.now()
+        self.update_download_progress = None
         self.refresh_update_progress_label()
         self.update_progress_timer.start()
 
@@ -536,6 +581,7 @@ class QMainWindowService(QMainWindowLoadSettings):
         self.update_progress_timer.stop()
         self.update_progress_started_at = None
         self.update_progress_step = step
+        self.update_download_progress = None
         self.refresh_update_progress_label()
 
     def choose_path_button_on_clicked(self):
@@ -1697,8 +1743,10 @@ class QMainWindowService(QMainWindowLoadSettings):
             SIGNAL.PRINT_TO_UI.emit(f"[更新] 已启动外部 updater，PID={launch_info['pid']}。主程序即将退出。", color_level=1)
             QtCore.QTimer.singleShot(500, QtWidgets.QApplication.quit)
 
-        self.git_worker = prepare_release_update(target)
+        self.git_worker = prepare_release_update(target, auto_start=False)
+        self.git_worker.progress.connect(self.update_download_progress_detail)
         self.git_worker.result.connect(on_prepare_result)
+        self.git_worker.start()
 
     def restart_application(self):
         """

--- a/function/core/update_prepare.py
+++ b/function/core/update_prepare.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from function.common.update_manifest import GitHubClient, compare_update_target
 from function.common.update_state import detect_local_state
@@ -100,13 +100,24 @@ def prepare_update_from_github(
     root: Path,
     target: dict[str, Any],
     selected_migration_names: set[str] | None = None,
+    progress_callback: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
     root = Path(root).resolve()
+    if progress_callback is not None:
+        progress_callback({
+            "phase": "prepare",
+            "message": "正在校验目标版本，尚未开始下载",
+        })
     validation = validate_update_target(root, target)
     if not validation["allowed"] and validation["status"] != "compare_failed":
         raise ValueError(validation["message"])
 
-    staging = prepare_staging_from_github(root, target)
+    if progress_callback is not None:
+        progress_callback({
+            "phase": "prepare",
+            "message": "目标版本校验完成，正在请求源码包",
+        })
+    staging = prepare_staging_from_github(root, target, progress_callback=progress_callback)
     migration_results = migrate_user_data(
         source_root=root,
         target_root=staging,

--- a/plugins/updater/updater.py
+++ b/plugins/updater/updater.py
@@ -3,6 +3,7 @@ import os
 import json
 import shutil
 import subprocess
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,6 +17,25 @@ UPDATER_STATE_RELATIVE_PATH = Path("update_cache") / "updater_state.json"
 
 def timestamp() -> str:
     return datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def console(message: str = "") -> None:
+    print(message, flush=True)
+
+
+def print_header(title: str, root: Path, log_path: Path) -> None:
+    console("=" * 60)
+    console(title)
+    console("=" * 60)
+    console(f"FAA 目录：{root}")
+    console(f"日志文件：{log_path}")
+    console()
+
+
+def countdown_and_exit(seconds: int = 3) -> None:
+    for remaining in range(seconds, 0, -1):
+        console(f"窗口将在 {remaining} 秒后自动关闭...")
+        time.sleep(1)
 
 
 def create_log_file(root: Path) -> Path:
@@ -171,23 +191,30 @@ def update(root: Path, staging_root: Path, launch: str | None, log_path: Path | 
     staging_root = ensure_directory(staging_root, "staging")
     ensure_child(root / "update_cache", staging_root, "staging")
     write_updater_state(root, "update_started", {"staging": str(staging_root)})
+    console("正在执行版本更新。")
+    console(f"新版本临时目录：{staging_root}")
 
     if log_path:
         log(log_path, f"update root={root} staging={staging_root}")
 
     backups_root = root / "backups"
+    console("正在备份当前版本...")
     write_updater_state(root, "backup_current_version")
     backup_dir = create_backup(root, backups_root, "FAA.backup")
     write_updater_state(root, "backup_created", {"backup": str(backup_dir)})
+    console(f"当前版本已备份到：{backup_dir}")
     if log_path:
         log(log_path, f"backup created: {backup_dir}")
 
     try:
+        console("正在替换为新版本文件...")
         write_updater_state(root, "installing_staging", {"backup": str(backup_dir)})
         move_items([item for item in staging_root.iterdir() if item.name not in PRESERVED_NAMES], root)
+        console("正在写入版本记录并清理更新临时文件...")
         install_packaged_state(root, staging_root)
         prune_failed_staging(root)
     except Exception:
+        console("更新失败，正在回滚到更新前版本...")
         write_updater_state(root, "rollback_started", {"backup": str(backup_dir)})
         failed_dir = backups_root / f"FAA.failed-update.{timestamp()}"
         move_items(version_items(root), failed_dir)
@@ -201,7 +228,9 @@ def update(root: Path, staging_root: Path, launch: str | None, log_path: Path | 
     if log_path:
         log(log_path, "update completed")
     write_updater_state(root, "update_completed", {"backup": str(backup_dir)})
+    console("版本更新完成，正在重新启动 FAA...")
     launch_entry(root, launch)
+    console("FAA 已启动。")
 
 
 def restore(root: Path, backup_dir: Path, launch: str | None, log_path: Path | None = None) -> None:
@@ -209,16 +238,21 @@ def restore(root: Path, backup_dir: Path, launch: str | None, log_path: Path | N
     backup_dir = ensure_directory(backup_dir, "backup")
     ensure_child(root / "backups", backup_dir, "backup")
     write_updater_state(root, "restore_started", {"backup": str(backup_dir)})
+    console("正在执行版本恢复。")
+    console(f"备份目录：{backup_dir}")
 
     if log_path:
         log(log_path, f"restore root={root} backup={backup_dir}")
 
+    console("正在备份当前版本，便于恢复失败时回滚...")
     new_backup = create_backup(root, root / "backups", "FAA.before-restore")
     write_updater_state(root, "restore_current_backup_created", {"backup": str(new_backup)})
+    console(f"当前版本已备份到：{new_backup}")
     if log_path:
         log(log_path, f"current version backed up: {new_backup}")
 
     try:
+        console("正在把选中的备份复制回 FAA 目录...")
         write_updater_state(root, "restoring_backup", {"backup": str(backup_dir)})
         copy_items([item for item in backup_dir.iterdir() if item.name != ".update_state.json"], root)
 
@@ -227,6 +261,7 @@ def restore(root: Path, backup_dir: Path, launch: str | None, log_path: Path | N
             backup_state["restored_at"] = datetime.now(timezone.utc).isoformat()
             write_json(state_path(root), backup_state)
     except Exception:
+        console("恢复失败，正在回滚到恢复前版本...")
         failed_dir = root / "backups" / f"FAA.failed-restore.{timestamp()}"
         write_updater_state(root, "restore_rollback_started", {"current_backup": str(new_backup)})
         move_items(version_items(root), failed_dir)
@@ -244,7 +279,9 @@ def restore(root: Path, backup_dir: Path, launch: str | None, log_path: Path | N
     if log_path:
         log(log_path, "restore completed")
     write_updater_state(root, "restore_completed", {"backup": str(backup_dir), "previous_current": str(new_backup)})
+    console("版本恢复完成，正在重新启动 FAA...")
     launch_entry(root, launch)
+    console("FAA 已启动。")
 
 
 def main() -> None:
@@ -268,18 +305,31 @@ def main() -> None:
     args = parser.parse_args()
     root = Path(args.root).resolve()
     log_path = create_log_file(root)
+    title = "FAA 自动更新工具" if args.command == "update" else "FAA 版本恢复工具"
+    print_header(title, root, log_path)
     try:
+        console("正在等待 FAA 主程序退出，避免文件被占用...")
         write_updater_state(root, "waiting_for_process", {"pid": args.wait_pid})
         wait_for_process_exit(args.wait_pid, log_path, args.wait_timeout)
+        console("FAA 主程序已退出，可以安全替换文件。")
         if args.command == "update":
             update(root, Path(args.staging), args.launch, log_path)
         elif args.command == "restore":
             restore(root, Path(args.backup), args.launch, log_path)
+        console()
+        console("操作已完成。")
+        countdown_and_exit(3)
     except Exception:
+        error = format_exc()
         log(log_path, "operation failed")
-        log(log_path, format_exc())
-        write_updater_state(root, "failed", {"error": format_exc()})
-        raise
+        log(log_path, error)
+        write_updater_state(root, "failed", {"error": error})
+        console()
+        console("[错误] 操作失败。")
+        console(f"详细日志已写入：{log_path}")
+        console(error)
+        countdown_and_exit(10)
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* 在检查更新页面显示源码包已下载体积、下载速度、百分比和预计剩余时间。
* GitHub 未提供总大小时显示大小未知，并将下载进度调整为每 0.5 秒平滑刷新。
* 在目标版本校验、下载连接、重试、备份、替换、恢复和重启阶段提供明确提示。
* 更新或恢复完成后保留三秒倒计时，失败时展示日志位置与错误信息。