### PR TITLE
fix(方案选择): 统一文件名称排序

### DIFF
--- a/function/common/file_name_sort.py
+++ b/function/common/file_name_sort.py
@@ -1,0 +1,49 @@
+import ctypes
+import re
+import sys
+from functools import cmp_to_key
+from typing import Iterable
+
+
+def _natural_sort_key(value: str) -> tuple[tuple[int, object], ...]:
+    """
+    为非 Windows 环境生成数字感知的文件名排序键。
+
+    Args:
+        value: 需要参与排序的文件名。
+
+    Returns:
+        由文本段和整数段组成的可比较元组。
+    """
+    sort_key = []
+    for part in re.split(r"(\d+)", value):
+        if not part:
+            continue
+        if part.isdecimal():
+            sort_key.append((0, int(part)))
+        else:
+            sort_key.append((1, part.casefold()))
+    return tuple(sort_key)
+
+
+def sort_file_names_like_windows(file_names: Iterable[str]) -> list[str]:
+    """
+    按 Windows 资源管理器的自然排序规则排列文件名。
+
+    Windows 下直接调用 Shell 的 `StrCmpLogicalW`，确保数字片段和资源管理器
+    一样按数值比较。非 Windows 环境使用等价的数字感知规则，方便开发测试。
+
+    Args:
+        file_names: 需要排序的文件名序列。
+
+    Returns:
+        排序后的新列表，不修改传入序列。
+    """
+    names = list(file_names)
+    if sys.platform != "win32":
+        return sorted(names, key=_natural_sort_key)
+
+    compare = ctypes.windll.shlwapi.StrCmpLogicalW
+    compare.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p)
+    compare.restype = ctypes.c_int
+    return sorted(names, key=cmp_to_key(compare))

--- a/function/scattered/get_list_battle_plan.py
+++ b/function/scattered/get_list_battle_plan.py
@@ -1,12 +1,18 @@
 import os
 
+from function.common.file_name_sort import sort_file_names_like_windows
 from function.globals.get_paths import PATHS
 
 
-def get_list_battle_plan(with_extension):
+def get_list_battle_plan(with_extension:bool):
     """
-    :param with_extension: Include extension name
-    :return: a list of battle plan
+    获取按 Windows 资源管理器规则排序的战斗方案文件名。
+
+    Args:
+        with_extension: 是否在返回结果中保留 `.json` 扩展名。
+
+    Returns:
+        排序后的战斗方案文件名列表；根据 `with_extension` 保留或移除扩展名。
     """
 
     # 获取战斗计划目录下的所有文件
@@ -14,6 +20,9 @@ def get_list_battle_plan(with_extension):
 
     # 过滤出 .json 文件
     my_list = [file for file in my_list if file.endswith('.json')]
+
+    # 按 Windows 资源管理器的自然排序规则排列文件名
+    my_list = sort_file_names_like_windows(my_list)
 
     if with_extension:
         return my_list
@@ -23,10 +32,15 @@ def get_list_battle_plan(with_extension):
         return my_list
 
 
-def get_list_tweak_plan(with_extension):
+def get_list_tweak_plan(with_extension:bool):
     """
-    :param with_extension: Include extension name
-    :return: a list of battle plan
+    获取按 Windows 资源管理器规则排序的微调方案文件名。
+
+    Args:
+        with_extension: 是否在返回结果中保留 `.json` 扩展名。
+
+    Returns:
+        排序后的微调方案文件名列表；根据 `with_extension` 保留或移除扩展名。
     """
 
     # 获取战斗计划目录下的所有文件
@@ -34,6 +48,9 @@ def get_list_tweak_plan(with_extension):
 
     # 过滤出 .json 文件
     my_list = [file for file in my_list if file.endswith('.json')]
+
+    # 按 Windows 资源管理器的自然排序规则排列文件名
+    my_list = sort_file_names_like_windows(my_list)
 
     if with_extension:
         return my_list

--- a/function/scattered/get_task_sequence_list.py
+++ b/function/scattered/get_task_sequence_list.py
@@ -1,28 +1,34 @@
 import os
 
+from function.common.file_name_sort import sort_file_names_like_windows
 from function.globals.get_paths import PATHS
 
 
-def get_task_sequence_list(with_extension):
+def get_task_sequence_list(with_extension:bool):
     """
-    :param with_extension: Include extension name
-    :return: a list of battle plan
+    获取按 Windows 资源管理器规则排序的任务序列文件名。
+
+    Args:
+        with_extension: 是否在返回结果中保留 `.json` 扩展名。
+
+    Returns:
+        排序后的任务序列文件名列表；根据 `with_extension` 保留或移除扩展名。
     """
+
+    # 获取任务序列目录下的所有文件
     my_list = os.listdir(PATHS["task_sequence"])
 
-    # 只保留json
-    new_list = []
-    for i in range(len(my_list)):
-        if my_list[i].split(".")[-1] == "json":
-            new_list.append(my_list[i])
-    my_list = new_list
+    # 过滤出 .json 文件
+    my_list = [file for file in my_list if file.endswith('.json')]
 
-    # 根据参数 是否保留后缀
+    # 按 Windows 资源管理器的自然排序规则排列文件名
+    my_list = sort_file_names_like_windows(my_list)
+
     if with_extension:
         return my_list
     else:
         for i in range(len(my_list)):
-            my_list[i] = my_list[i].split(".")[0]
+            my_list[i] = my_list[i].rsplit('.', 1)[0]
         return my_list
 
 

--- a/test/test_file_name_sort.py
+++ b/test/test_file_name_sort.py
@@ -1,0 +1,63 @@
+import unittest
+from unittest.mock import patch
+
+from function.common.file_name_sort import sort_file_names_like_windows
+from function.scattered.get_list_battle_plan import (
+    get_list_battle_plan,
+    get_list_tweak_plan,
+)
+from function.scattered.get_task_sequence_list import get_task_sequence_list
+
+
+class FileNameSortTest(unittest.TestCase):
+    def test_sort_matches_windows_numeric_order(self):
+        names = [
+            "NO-6-10-1P 多拿滋.json",
+            "NO-6-3to4 苏打水.json",
+            "NO-6-7-1P 巴旦木.json",
+            "NO-6-5 汉堡王.json",
+        ]
+
+        self.assertEqual(
+            sort_file_names_like_windows(names),
+            [
+                "NO-6-3to4 苏打水.json",
+                "NO-6-5 汉堡王.json",
+                "NO-6-7-1P 巴旦木.json",
+                "NO-6-10-1P 多拿滋.json",
+            ],
+        )
+
+    @patch(
+        "function.scattered.get_list_battle_plan.os.listdir",
+        return_value=["方案10.json", "说明.txt", "方案2.json", "方案1.json"],
+    )
+    def test_battle_plan_list_is_sorted_without_extension(self, _listdir):
+        self.assertEqual(
+            get_list_battle_plan(with_extension=False),
+            ["方案1", "方案2", "方案10"],
+        )
+
+    @patch(
+        "function.scattered.get_list_battle_plan.os.listdir",
+        return_value=["微调10.json", "微调2.json", "微调1.json"],
+    )
+    def test_tweak_plan_list_is_sorted_with_extension(self, _listdir):
+        self.assertEqual(
+            get_list_tweak_plan(with_extension=True),
+            ["微调1.json", "微调2.json", "微调10.json"],
+        )
+
+    @patch(
+        "function.scattered.get_task_sequence_list.os.listdir",
+        return_value=["任务10.json", "说明.txt", "任务2.json", "任务1.json"],
+    )
+    def test_task_sequence_list_is_sorted_without_extension(self, _listdir):
+        self.assertEqual(
+            get_task_sequence_list(with_extension=False),
+            ["任务1", "任务2", "任务10"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* 战斗方案、微调方案和任务序列待选列表统一采用 Windows 资源管理器自然排序。
* Windows 环境直接使用 Shell `StrCmpLogicalW`，确保数字片段顺序与系统一致。
* 保持方案名称与 UUID 映射顺序一致，并补充文件过滤、扩展名和数字排序测试。
* 对应 Issue #957 第一项，不关闭仍包含其他反馈的 Issue。