### PR TITLE
fix(全局方案）: 修复打错控件名字导致不更新2P候选战斗方案下拉列表

### DIFF
--- a/function/core/qmw_editor_of_stage_plan.py
+++ b/function/core/qmw_editor_of_stage_plan.py
@@ -173,7 +173,7 @@ class QMWEditorOfStagePlan(QMainWindow):
             widget.blockSignals(False)
 
         change_one(widget=self.GlobalBattlePlanBox1P)
-        change_one(widget=self.GlobalBattlePlanBox1P)
+        change_one(widget=self.GlobalBattlePlanBox2P)
         change_one(widget=self.StageBattlePlanBox1P)
         change_one(widget=self.StageBattlePlanBox2P)
         change_two(widget=self.StageTweakBattlePlanBox)


### PR DESCRIPTION
此PR修复了3.1.1中，当创建新的战斗方案后，全局方案编辑器中2P的下拉选项框无法自动更新。

----

修typo，破事水

未进行构建测试，可用性未知