### PR TITLE
fix(二级密码): 恢复通过暗晶商店触发密码输入

### DIFF
--- a/function/core/faa/faa_core.py
+++ b/function/core/faa/faa_core.py
@@ -3033,17 +3033,39 @@ class FAABase:
 
     def input_level_2_password(self: "FAA", password: str):
         """
-        输入二级密码. 通过背包内尝试拆主武器
+        输入二级密码.
         """
 
-        SIGNAL.PRINT_TO_UI.emit(text=f"[输入二级密码] [{self.player}P] 开始.")
+        SIGNAL.PRINT_TO_UI.emit(text=f"[输入二级密码] [{self.player}P] 开始. 默认通过暗晶商店, 请确保加入公会.")
 
-        # 打开背包
-        self.action_bottom_menu(mode="背包")
-        time.sleep(5)
+        # 打开公会副本界面
+        self.print_debug(text="跳转到公会副本界面")
+        self.action_bottom_menu(mode="跳转_公会副本")
 
-        # 卸下主武器
-        T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=210, y=445)
+        # 打开暗晶商店
+        T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=800, y=485)
+
+        # 确保加载正确完成
+        r = loop_match_p_in_w(
+            source_handle=self.handle,
+            source_range=[255, 15, 655, 60],
+            template=RESOURCE_P["common"]["暗晶商店_ui.png"],
+            match_tolerance=0.95,
+            match_interval=0.2,
+            match_failed_check=10,
+            after_sleep=0.2,
+            click=False
+        )
+        if not r:
+            SIGNAL.PRINT_TO_UI.emit(text=f"[输入二级密码] [{self.player}P] 失败? 请确认加入了公会.")
+            return False
+
+        # 进入暗晶兑换
+        T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=180, y=70)
+        time.sleep(1)
+
+        # 兑换 弹出框体
+        T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=405, y=190)
         time.sleep(1)
 
         # 点击输入框选中
@@ -3060,10 +3082,12 @@ class FAABase:
         T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=435, y=388)
         time.sleep(1)
 
-        # 关闭背包
-        self.action_exit(mode="普通红叉")
+        # 退出商店界面
+        for i in range(2):
+            self.action_exit(mode="普通红叉")
 
         SIGNAL.PRINT_TO_UI.emit(text=f"[输入二级密码] [{self.player}P] 结束.")
+        return True
 
     def gift_flower(self: "FAA"):
         """送免费花"""

--- a/function/core/todo.py
+++ b/function/core/todo.py
@@ -272,8 +272,8 @@ class ThreadTodo(QThread):
         def run_delete(cur_player):
             password = self.opt["level_2"][f"{cur_player}p"]["password"]
             faa = self.faa_dict[cur_player]
-            faa.input_level_2_password(password=password)
-            faa.delete_items()
+            if faa.input_level_2_password(password=password):
+                faa.delete_items()
 
         self.thread_1p = ThreadWithException(
             target=run_delete,
@@ -324,8 +324,8 @@ class ThreadTodo(QThread):
         def run_get_dark_crystal(cur_player):
             password = self.opt["level_2"][f"{cur_player}p"]["password"]
             faa = self.faa_dict[cur_player]
-            faa.input_level_2_password(password=password)
-            faa.get_dark_crystal()
+            if faa.input_level_2_password(password=password):
+                faa.get_dark_crystal()
 
         self.thread_1p = ThreadWithException(
             target=run_get_dark_crystal,
@@ -376,8 +376,8 @@ class ThreadTodo(QThread):
         def run_gdisenchant_geml(cur_player):
             password = self.opt["level_2"][f"{cur_player}p"]["password"]
             faa = self.faa_dict[cur_player]
-            faa.input_level_2_password(password=password)
-            faa.disenchant_gem()
+            if faa.input_level_2_password(password=password):
+                faa.disenchant_gem()
 
         self.thread_1p = ThreadWithException(
             target=run_gdisenchant_geml,


### PR DESCRIPTION
* 恢复通过公会暗晶商店兑换操作触发二级密码输入框，避免依赖拆卸主武器。
* 增加暗晶商店界面识别与失败返回，未加入公会时给出明确提示。
* 删除物品、兑换暗晶和宝石分解仅在二级密码输入成功后继续执行。