### PR TITLE
fix(微调方案): 禁用承载/冰沙/创造神/幻鸡时，将同时禁用自动带卡与智能使用

### DIFF
--- a/function/core/faa/faa_battle_preparation.py
+++ b/function/core/faa/faa_battle_preparation.py
@@ -11,6 +11,7 @@ from function.common.bg_img_match import loop_match_ps_in_w, loop_match_p_in_w, 
 from function.common.bg_img_screenshot import capture_image_png
 from function.common.image_processing.overlay_images import overlay_images
 from function.core.analyzer_of_loot_logs import match_items_from_image_and_save
+from function.core.faa.tweak_plan import get_tweak_plan_ban_state
 from function.globals import SIGNAL, EXTRA
 from function.globals.g_resources import RESOURCE_P
 from function.globals.get_paths import PATHS
@@ -690,21 +691,16 @@ class BattlePreparation:
             SIGNAL.PRINT_TO_UI.emit(f"检测到特殊关卡：{stage_name}，已为你启用对应关卡信息(铲卡/承载)", 7)
 
     def _auto_carry_card_get_card_name_list_from_battle_plan(self: "FAA"):
-        # 强制禁用状态
-        ban_mat = False
-        ban_icecream = False
-        ban_god = False
-        ban_ikun = False
-        ban_coffee = False
-        if self.battle_plan_tweak:
-            ban_state = self.battle_plan_tweak["meta_data"].get("ban_state", None)
-            if ban_state:
-                ban_mat = ban_state.get("mat", False)
-                ban_icecream = ban_state.get("icecream", False)
-                ban_god = ban_state.get("god", False)
-                ban_ikun = ban_state.get("ikun", False)
-                ban_coffee = ban_state.get("coffee", False)
-            pass
+        """
+        根据战斗方案和微调方案生成自动带卡清单。
+
+        微调方案中的 ban_state 用于关闭对应辅助卡片的自动携带功能；
+        同一状态还会在战斗初始化阶段关闭对应的智能使用功能。
+
+        Returns:
+            按卡片优先级排列的自动带卡要求列表。
+        """
+        ban_state = get_tweak_plan_ban_state(self.battle_plan_tweak)
         my_dict = {}
         mats = copy.deepcopy(self.stage_info["mat_card"])
 
@@ -720,19 +716,19 @@ class BattlePreparation:
             required_cards_list.append({"name": card, "can_failed": False})
 
         # 如果需要任意承载卡 第一张卡设定为 有效承载 置于末位
-        if len(mats) >= 1 and not ban_mat:
+        if len(mats) >= 1 and not ban_state["mat"]:
             required_cards_list.append({"name": "有效承载", "can_failed": False})
 
         # 添加冰沙 复制类 置于末位 允许找不到
-        if not ban_icecream:
+        if not ban_state["icecream"]:
             required_cards_list.append({"name": "冰激凌-2", "can_failed": True})
-        if not ban_god:
+        if not ban_state["god"]:
             required_cards_list.append({"name": "创造神", "can_failed": True})
-        if not ban_ikun:
+        if not ban_state["ikun"]:
             required_cards_list.append({"name": "幻幻鸡", "can_failed": True})
 
         # 如果有效承载数量 >= 2 置于末位 允许找不到
-        if len(mats) >= 2 and not ban_mat:
+        if len(mats) >= 2 and not ban_state["mat"]:
             for _ in range(len(mats) - 1):
                 required_cards_list.append({"name": "有效承载", "can_failed": True})
 
@@ -747,7 +743,7 @@ class BattlePreparation:
             else:
                 self.ban_card_list += ["咖啡粉"]
 
-        if ban_coffee:
+        if ban_state["coffee"]:
             if not self.ban_card_list:
                 self.ban_card_list = ["咖啡粉"]
             elif "咖啡粉" not in self.ban_card_list:

--- a/function/core/faa/faa_core.py
+++ b/function/core/faa/faa_core.py
@@ -15,6 +15,7 @@ from function.common.get_system_dpi import get_window_position, get_system_dpi
 from function.common.image_processing.overlay_images import overlay_images
 from function.common.process_manager import close_software_by_title, get_path_and_sub_titles, \
     close_all_software_by_name, start_software_with_args
+from function.core.faa.tweak_plan import get_auto_card_target_names
 from function.core.my_crypto import decrypt_data
 from function.core_battle.get_location_in_battle import get_location_card_deck_in_battle
 from function.globals import g_resources, SIGNAL, EXTRA
@@ -658,15 +659,18 @@ class FAABase:
 
     def init_mat_smoothie_kun_card_info(self: "FAA") -> None:
         """
-        根据关卡名称和可用承载卡，以及游戏内识图到的承载卡取交集，返回承载卡的x-y坐标
-        :return: [[x1, y1], [x2, y2],...]
+        识别本场战斗允许自动使用的承载卡、冰沙和连携卡。
+
+        微调方案禁用某类辅助卡片后，不再识别该类卡片，也不会为其自动生成
+        承载铺设、冰沙放置或创造神/幻幻鸡连携逻辑。
         """
 
-        self.print_info("战斗中识图查找承载卡/冰沙/坤位置, 开始")
+        self.print_info("战斗中识图查找启用的承载卡/冰沙/连携卡位置, 开始")
 
-        target_mat_list = copy.deepcopy(self.stage_info["mat_card"])
-        target_smoothie_list = ["冰激凌"]
-        target_kun_list = ["幻幻鸡", "创造神"]
+        target_mat_list, target_smoothie_list, target_kun_list = get_auto_card_target_names(
+            stage_mat_card_names=self.stage_info["mat_card"],
+            battle_plan_tweak=self.battle_plan_tweak,
+        )
 
         def scan(target_names_list, image):
             """
@@ -772,7 +776,7 @@ class FAABase:
                 if check_coordinate(card_xy_list=card_xy_list):
                     kun_cards_info.append({'name': card_name, "card_id": card_id})
         self.kun_cards_info = kun_cards_info
-        self.print_info(text="战斗中识图查找幻幻鸡位置, 结果：{}".format(self.kun_cards_info))
+        self.print_info(text="战斗中识图查找连携卡位置, 结果：{}".format(self.kun_cards_info))
 
     def init_battle_plan_card(self: "FAA", wave: int) -> None:
         """

--- a/function/core/faa/tweak_plan.py
+++ b/function/core/faa/tweak_plan.py
@@ -1,0 +1,59 @@
+import copy
+
+
+def get_tweak_plan_ban_state(battle_plan_tweak) -> dict[str, bool]:
+    """
+    获取微调方案中各类自动辅助卡片功能的禁用状态。
+
+    `mat`、`icecream`、`god` 和 `ikun` 为 True 时，同时停止该类卡片的
+    自动携带与智能使用。`coffee` 暂时保留原有的直接禁用携带行为。
+
+    Args:
+        battle_plan_tweak: 已加载的微调方案字典；缺失或格式异常时使用默认值。
+
+    Returns:
+        包含 mat、icecream、god、ikun、coffee 五个布尔字段的完整字典。
+    """
+    default_state = {
+        "mat": False,
+        "icecream": False,
+        "god": False,
+        "ikun": False,
+        "coffee": False,
+    }
+    if not isinstance(battle_plan_tweak, dict):
+        return default_state
+
+    ban_state = battle_plan_tweak.get("meta_data", {}).get("ban_state", {})
+    if not isinstance(ban_state, dict):
+        return default_state
+
+    for name in default_state:
+        default_state[name] = ban_state.get(name, False) is True
+    return default_state
+
+
+def get_auto_card_target_names(
+        stage_mat_card_names: list[str],
+        battle_plan_tweak,
+) -> tuple[list[str], list[str], list[str]]:
+    """
+    获取本场战斗允许智能识别和使用的辅助卡片名称。
+
+    Args:
+        stage_mat_card_names: 当前关卡允许使用的承载卡名称。
+        battle_plan_tweak: 已加载的微调方案字典。
+
+    Returns:
+        三个列表依次为承载卡、冰沙和连携卡的识别目标名称。微调方案
+        禁用某一功能时，对应列表为空。
+    """
+    ban_state = get_tweak_plan_ban_state(battle_plan_tweak)
+    target_mat_list = [] if ban_state["mat"] else copy.deepcopy(stage_mat_card_names)
+    target_smoothie_list = [] if ban_state["icecream"] else ["冰激凌"]
+    target_kun_list = []
+    if not ban_state["ikun"]:
+        target_kun_list.append("幻幻鸡")
+    if not ban_state["god"]:
+        target_kun_list.append("创造神")
+    return target_mat_list, target_smoothie_list, target_kun_list

--- a/resource/template/!默认.json
+++ b/resource/template/!默认.json
@@ -10,6 +10,14 @@
         "cd_after_use_random_range-tip" : "list[float,float] 战斗中放一张卡后的间隔值的随机范围, null则不启用. 用于在巅峰对决中让faa变笨笨",
         "cd_after_use_random_range": null,
         "senior_setting-tip" : "bool, 是否开启高级战斗",
-        "senior_setting": false
+        "senior_setting": false,
+        "ban_state-tip": "mat、icecream、god、ikun 为 true 时，同时关闭对应辅助卡片的自动携带和智能使用；coffee 为 true 时直接禁用咖啡粉携带",
+        "ban_state": {
+            "mat": false,
+            "icecream": false,
+            "god": false,
+            "ikun": false,
+            "coffee": false
+        }
     }
 }

--- a/test/test_tweak_plan_ban_state.py
+++ b/test/test_tweak_plan_ban_state.py
@@ -1,0 +1,79 @@
+import unittest
+
+from function.core.faa.tweak_plan import get_auto_card_target_names, get_tweak_plan_ban_state
+
+
+class TweakPlanBanStateTest(unittest.TestCase):
+    def setUp(self):
+        self.stage_mat_card_names = ["木盘子", "麦芽糖浆"]
+        self.battle_plan_tweak = {"meta_data": {}}
+
+    def test_default_state_keeps_all_auto_card_features(self):
+        self.assertEqual(
+            get_tweak_plan_ban_state(self.battle_plan_tweak),
+            {
+                "mat": False,
+                "icecream": False,
+                "god": False,
+                "ikun": False,
+                "coffee": False,
+            },
+        )
+        self.assertEqual(
+            get_auto_card_target_names(self.stage_mat_card_names, self.battle_plan_tweak),
+            (["木盘子", "麦芽糖浆"], ["冰激凌"], ["幻幻鸡", "创造神"]),
+        )
+
+    def test_ban_state_removes_corresponding_auto_card_targets(self):
+        self.battle_plan_tweak = {
+            "meta_data": {
+                "ban_state": {
+                    "mat": True,
+                    "icecream": True,
+                    "god": True,
+                    "ikun": True,
+                }
+            }
+        }
+
+        self.assertEqual(
+            get_auto_card_target_names(self.stage_mat_card_names, self.battle_plan_tweak),
+            ([], [], []),
+        )
+
+    def test_god_and_ikun_can_be_disabled_independently(self):
+        self.battle_plan_tweak = {
+            "meta_data": {
+                "ban_state": {
+                    "god": True,
+                }
+            }
+        }
+        self.assertEqual(
+            get_auto_card_target_names(self.stage_mat_card_names, self.battle_plan_tweak),
+            (["木盘子", "麦芽糖浆"], ["冰激凌"], ["幻幻鸡"]),
+        )
+
+        self.battle_plan_tweak["meta_data"]["ban_state"] = {"ikun": True}
+        self.assertEqual(
+            get_auto_card_target_names(self.stage_mat_card_names, self.battle_plan_tweak),
+            (["木盘子", "麦芽糖浆"], ["冰激凌"], ["创造神"]),
+        )
+
+    def test_non_boolean_values_do_not_enable_ban(self):
+        self.battle_plan_tweak = {
+            "meta_data": {
+                "ban_state": {
+                    "mat": "true",
+                    "icecream": 1,
+                }
+            }
+        }
+
+        ban_state = get_tweak_plan_ban_state(self.battle_plan_tweak)
+        self.assertFalse(ban_state["mat"])
+        self.assertFalse(ban_state["icecream"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tweak_plan/!默认.json
+++ b/tweak_plan/!默认.json
@@ -10,6 +10,14 @@
         "cd_after_use_random_range-tip" : "list[float,float] 战斗中放一张卡后的间隔值的随机范围, null则不启用. 用于在巅峰对决中让faa变笨笨",
         "cd_after_use_random_range": null,
         "senior_setting-tip" : "bool, 是否开启高级战斗",
-        "senior_setting": false
+        "senior_setting": false,
+        "ban_state-tip": "mat、icecream、god、ikun 为 true 时，同时关闭对应辅助卡片的自动携带和智能使用；coffee 为 true 时直接禁用咖啡粉携带",
+        "ban_state": {
+            "mat": false,
+            "icecream": false,
+            "god": false,
+            "ikun": false,
+            "coffee": false
+        }
     }
 }

--- a/tweak_plan/强制禁用卡片.json
+++ b/tweak_plan/强制禁用卡片.json
@@ -1,14 +1,14 @@
 {
     "meta_data": {
         "uuid": "00000000-0000-0000-0000-000000000003",
-        "tips": "该方案设置了强制禁用卡片垫子，冰沙，创造神，幻坤",
+        "tips": "关闭承载卡、冰沙、创造神和幻幻鸡的自动携带与智能使用功能",
         "version": "0.3",
         "ban_state": {
-        "mat": true,
-        "icecream": true,
-        "god": true,
-        "ikun": true,
-        "coffee": false
-        }        
+            "mat": true,
+            "icecream": true,
+            "god": true,
+            "ikun": true,
+            "coffee": false
+        }
     }
 }


### PR DESCRIPTION
* 统一解析微调方案的 ban_state，缺失或格式异常时安全使用默认值。
* 禁用承载卡后，不再根据关卡承载信息自动带卡、识别承载卡或生成承载铺设信息。
* 禁用冰沙后，不再自动携带冰激凌，也不再生成冰沙自动放卡信息。
* 创造神与幻幻鸡分别受 god、ikun 参数管理，不再自动携带或参与连携使用。
* 更新默认及强制禁用微调方案，并补充独立参数与异常值测试。