### PR TITLE
feat(自动承载): 支持自定义使用优先级

### DIFF
--- a/function/core/faa/faa_core.py
+++ b/function/core/faa/faa_core.py
@@ -20,6 +20,8 @@ from function.core.faa.tweak_plan import (
     build_auto_timer_card,
     get_auto_card_target_names,
     get_auto_timer_target_names,
+    get_tweak_plan_mat_card_first,
+    insert_mat_cards_by_priority,
 )
 from function.core.my_crypto import decrypt_data
 from function.core_battle.get_location_in_battle import get_location_card_deck_in_battle
@@ -944,7 +946,7 @@ class FAABase:
             return list_new
 
         def calculation_card_mat(list_cell_all):
-            """步骤三 承载卡"""
+            """步骤三：按微调方案优先级加入自动承载卡。"""
 
             location = stage_info["mat_cell"]  # 深拷贝 防止对配置文件数据更改
 
@@ -963,25 +965,21 @@ class FAABase:
                 any(card['name'] == "木盘子" for card in mat_card_info)
             )
 
+            mat_cards = []
             for i in range(num_mat_card):
-
-                dict_mat = {
+                mat_cards.append({
                     "card_id": mat_card_info[i]['card_id'],
                     "name": mat_card_info[i]['name'],
                     "location": location[i::num_mat_card],
                     "ergodic": need_ergodic,
                     "queue": True
-                }
+                })
 
-                # 可能是空列表 即花瓶
-                if len(list_cell_all) == 0:
-                    # 首位插入
-                    list_cell_all.insert(0, dict_mat)
-                else:
-                    # 第二位插入
-                    list_cell_all.insert(1, dict_mat)
-
-            return list_cell_all
+            return insert_mat_cards_by_priority(
+                cards=list_cell_all,
+                mat_cards=mat_cards,
+                mat_card_first=get_tweak_plan_mat_card_first(self.battle_plan_tweak),
+            )
 
         def calculation_card_extra(list_cell_all):
 

--- a/function/core/faa/tweak_plan.py
+++ b/function/core/faa/tweak_plan.py
@@ -4,6 +4,7 @@ from function.core_battle.card_copy_rules import get_creator_god_safe_locations
 
 
 AUTO_TIMER_DEFAULT = False
+MAT_CARD_FIRST_DEFAULT = True
 
 
 def get_tweak_plan_ban_state(battle_plan_tweak) -> dict[str, bool]:
@@ -76,6 +77,41 @@ def get_tweak_plan_auto_timer_enabled(battle_plan_tweak) -> bool:
         return AUTO_TIMER_DEFAULT
     value = enable_auto_card.get("timer")
     return value if isinstance(value, bool) else AUTO_TIMER_DEFAULT
+
+
+def get_tweak_plan_mat_card_first(battle_plan_tweak) -> bool:
+    """
+    读取是否让自动承载卡先于战斗方案首卡使用。
+
+    ``True`` 适用于零费承载；``False`` 适用于需要火苗的低练度承载，
+    可先执行战斗方案首卡以启动产火循环。
+    """
+    if not isinstance(battle_plan_tweak, dict):
+        return MAT_CARD_FIRST_DEFAULT
+    meta_data = battle_plan_tweak.get("meta_data", {})
+    if not isinstance(meta_data, dict):
+        return MAT_CARD_FIRST_DEFAULT
+
+    settings = meta_data.get("auto_mat_card", {})
+    if isinstance(settings, dict) and isinstance(settings.get("use_first"), bool):
+        return settings["use_first"]
+
+    # 兼容已经使用过的旧平铺字段。
+    legacy_value = meta_data.get("mat_card_first")
+    if isinstance(legacy_value, bool):
+        return legacy_value
+    return MAT_CARD_FIRST_DEFAULT
+
+
+def insert_mat_cards_by_priority(
+        cards: list[dict],
+        mat_cards: list[dict],
+        mat_card_first: bool,
+) -> list[dict]:
+    """按玩家选择把整组自动承载卡插入执行优先级。"""
+    insert_index = 0 if mat_card_first else min(1, len(cards))
+    cards[insert_index:insert_index] = mat_cards
+    return cards
 
 
 def get_highest_kun_target_from_cards(cards: list[dict]) -> dict | None:

--- a/resource/template/!默认.json
+++ b/resource/template/!默认.json
@@ -22,6 +22,10 @@
         "enable_auto_card-tip": "timer 为 true 时，在存在正数 kun 目标的战斗方案中自动携带并使用美味计时器",
         "enable_auto_card": {
             "timer": false
+        },
+        "auto_mat_card-tip": "use_first 为 true 时承载卡优先；false 时保留战斗方案首卡在最前，承载卡紧随其后",
+        "auto_mat_card": {
+            "use_first": true
         }
     }
 }

--- a/test/test_auto_mat_priority.py
+++ b/test/test_auto_mat_priority.py
@@ -1,0 +1,56 @@
+import unittest
+
+from function.core.faa.tweak_plan import (
+    get_tweak_plan_mat_card_first,
+    insert_mat_cards_by_priority,
+)
+
+
+class AutoMatPriorityTest(unittest.TestCase):
+    def test_default_keeps_existing_mat_first_behavior(self):
+        self.assertTrue(get_tweak_plan_mat_card_first({"meta_data": {}}))
+        self.assertTrue(get_tweak_plan_mat_card_first(None))
+
+    def test_nested_setting_accepts_explicit_false(self):
+        tweak = {"meta_data": {"auto_mat_card": {"use_first": False}}}
+        self.assertFalse(get_tweak_plan_mat_card_first(tweak))
+
+    def test_legacy_flat_setting_remains_compatible(self):
+        tweak = {"meta_data": {"mat_card_first": False}}
+        self.assertFalse(get_tweak_plan_mat_card_first(tweak))
+
+    def test_mat_cards_can_run_before_all_plan_cards(self):
+        cards = [{"name": "产火卡"}, {"name": "输出卡"}]
+        mats = [{"name": "承载一"}, {"name": "承载二"}]
+        self.assertEqual(
+            insert_mat_cards_by_priority(cards, mats, True),
+            [
+                {"name": "承载一"},
+                {"name": "承载二"},
+                {"name": "产火卡"},
+                {"name": "输出卡"},
+            ],
+        )
+
+    def test_plan_first_keeps_only_first_plan_card_ahead_of_mats(self):
+        cards = [{"name": "产火卡"}, {"name": "输出卡"}]
+        mats = [{"name": "承载一"}, {"name": "承载二"}]
+        self.assertEqual(
+            insert_mat_cards_by_priority(cards, mats, False),
+            [
+                {"name": "产火卡"},
+                {"name": "承载一"},
+                {"name": "承载二"},
+                {"name": "输出卡"},
+            ],
+        )
+
+    def test_empty_plan_still_places_mats_first(self):
+        self.assertEqual(
+            insert_mat_cards_by_priority([], [{"name": "承载"}], False),
+            [{"name": "承载"}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tweak_plan/!默认.json
+++ b/tweak_plan/!默认.json
@@ -22,6 +22,10 @@
         "enable_auto_card-tip": "timer 为 true 时，在存在正数 kun 目标的战斗方案中自动携带并使用美味计时器",
         "enable_auto_card": {
             "timer": false
+        },
+        "auto_mat_card-tip": "use_first 为 true 时承载卡优先；false 时保留战斗方案首卡在最前，承载卡紧随其后",
+        "auto_mat_card": {
+            "use_first": true
         }
     }
 }


### PR DESCRIPTION
* 新增 auto_mat_card.use_first 微调选项，允许用户选择自动承载卡与战斗方案首卡的执行顺序。
* use_first 为 true 时，整组自动承载卡放在队列最前，适用于零费或高练度承载卡。
* use_first 为 false 时，保留战斗方案首卡在最前，自动承载卡紧随其后，避免需要火苗的承载卡阻塞产火首卡。
* 多张自动承载卡会保持原有顺序成组插入，不再因为逐张 insert 造成顺序反转。
* 空战斗方案仍会把自动承载卡正常放在队首，不会因缺少首卡产生异常。
* 默认微调方案和发行模板保持 use_first=true，确保旧用户继续沿用原有的承载优先行为。
* 兼容旧版平铺字段 mat_card_first，已有自定义微调方案无需立即迁移。