### PR TITLE
fix(自动卡): 避免自动用卡与战斗方案用卡冲突

### DIFF
--- a/function/core/faa/faa_battle_preparation.py
+++ b/function/core/faa/faa_battle_preparation.py
@@ -12,10 +12,8 @@ from function.common.bg_img_screenshot import capture_image_png
 from function.common.image_processing.overlay_images import overlay_images
 from function.core.analyzer_of_loot_logs import match_items_from_image_and_save
 from function.core.faa.tweak_plan import (
-    battle_plan_has_creator_god_target,
+    get_auto_card_target_names,
     get_auto_timer_target_names,
-    get_tweak_plan_auto_card_enabled,
-    get_tweak_plan_auto_mat_card,
 )
 from function.globals import SIGNAL, EXTRA
 from function.globals.g_resources import RESOURCE_P
@@ -167,7 +165,19 @@ class BattlePreparation:
                     targets_1.append(card)
                 # 模糊匹配 允许任意变种
                 else:
-                    targets_1 += [f"{card}-{i}" for i in range(3, -1, -1)]
+                    resource_prefix = f"{card}-"
+                    available_targets = []
+                    for resource_name in RESOURCE_P["card"]["准备房间"]:
+                        if not resource_name.startswith(resource_prefix) or not resource_name.endswith(".png"):
+                            continue
+                        precise_name = resource_name[:-4]
+                        stage_text = precise_name.rsplit("-", 1)[-1]
+                        if stage_text.isdigit():
+                            available_targets.append((int(stage_text), precise_name))
+                    targets_1 += [
+                        precise_name
+                        for _, precise_name in sorted(available_targets, reverse=True)
+                    ]
 
         # 只携带被记录图片的卡
         targets_1 = [card for card in targets_1 if (card + ".png") in RESOURCE_P["card"]["准备房间"]]
@@ -705,12 +715,13 @@ class BattlePreparation:
         Returns:
             按卡片优先级排列的自动带卡要求列表。
         """
-        auto_card_enabled = get_tweak_plan_auto_card_enabled(self.battle_plan_tweak)
-        auto_mat_enabled = get_tweak_plan_auto_mat_card(
-            self.battle_plan_tweak
-        )["enabled"]
         my_dict = {}
-        mats = copy.deepcopy(self.stage_info["mat_card"])
+        target_mat_list, target_smoothie_list, target_kun_list = get_auto_card_target_names(
+            stage_mat_card_names=self.stage_info["mat_card"],
+            battle_plan_tweak=self.battle_plan_tweak,
+            battle_plan=self.battle_plan,
+            card_types=self.card_types,
+        )
 
         # 直接从cards 中获取 顺带保险排序一下
         for card in self.battle_plan["cards"]:
@@ -724,27 +735,25 @@ class BattlePreparation:
             required_cards_list.append({"name": card, "can_failed": False})
 
         # 如果需要任意承载卡 第一张卡设定为 有效承载 置于末位
-        if len(mats) >= 1 and auto_mat_enabled:
+        if target_mat_list:
             required_cards_list.append({"name": "有效承载", "can_failed": False})
 
         # 添加计时器、冰沙和复制类卡片，置于末位且允许找不到。
         if get_auto_timer_target_names(
                 battle_plan_tweak=self.battle_plan_tweak,
                 battle_plan=self.battle_plan,
+                card_types=self.card_types,
         ):
             required_cards_list.append({"name": "美味计时器", "can_failed": True})
-        if auto_card_enabled["icecream"]:
+        if target_smoothie_list:
             required_cards_list.append({"name": "冰激凌-2", "can_failed": True})
-        if (
-                auto_card_enabled["god"]
-                and battle_plan_has_creator_god_target(self.battle_plan)
-        ):
+        if "创造神" in target_kun_list:
             required_cards_list.append({"name": "创造神", "can_failed": True})
-        if auto_card_enabled["ikun"]:
+        if "幻幻鸡" in target_kun_list:
             required_cards_list.append({"name": "幻幻鸡", "can_failed": True})
         # 如果有效承载数量 >= 2 置于末位 允许找不到
-        if len(mats) >= 2 and auto_mat_enabled:
-            for _ in range(len(mats) - 1):
+        if len(target_mat_list) >= 2:
+            for _ in range(len(target_mat_list) - 1):
                 required_cards_list.append({"name": "有效承载", "can_failed": True})
 
         # 根据最大卡片数量限制 移除卡片

--- a/function/core/faa/faa_core.py
+++ b/function/core/faa/faa_core.py
@@ -16,7 +16,6 @@ from function.common.image_processing.overlay_images import overlay_images
 from function.common.process_manager import close_software_by_title, get_path_and_sub_titles, \
     close_all_software_by_name, start_software_with_args
 from function.core.faa.tweak_plan import (
-    battle_plan_has_creator_god_target,
     build_auto_timer_card,
     get_auto_card_target_names,
     get_auto_timer_target_names,
@@ -678,14 +677,13 @@ class FAABase:
         target_mat_list, target_smoothie_list, target_kun_list = get_auto_card_target_names(
             stage_mat_card_names=self.stage_info["mat_card"],
             battle_plan_tweak=self.battle_plan_tweak,
+            battle_plan=self.battle_plan,
+            card_types=self.card_types,
         )
-        if not battle_plan_has_creator_god_target(self.battle_plan):
-            target_kun_list = [
-                name for name in target_kun_list if name != "创造神"
-            ]
         target_timer_list = get_auto_timer_target_names(
             battle_plan_tweak=self.battle_plan_tweak,
             battle_plan=self.battle_plan,
+            card_types=self.card_types,
         )
 
         def scan(

--- a/function/core/faa/tweak_plan.py
+++ b/function/core/faa/tweak_plan.py
@@ -1,4 +1,5 @@
 import copy
+import re
 
 from function.core_battle.card_copy_rules import get_creator_god_safe_locations
 
@@ -103,9 +104,41 @@ def get_tweak_plan_auto_card_enabled(battle_plan_tweak) -> dict[str, bool]:
     return enabled
 
 
+def _base_card_name(card_name: str) -> str:
+    """按 FAA 卡片类型解析规则截取卡名中的中文主体。"""
+    match = re.match(r"^(.*[\u4e00-\u9fff])", str(card_name))
+    return match.group(1) if match else str(card_name)
+
+
+def _card_name_candidates(card_name: str, card_types: list[dict] | None) -> set[str]:
+    """展开一个战斗方案卡名可能解析到的实际卡名。"""
+    base_name = _base_card_name(card_name)
+    for card_type in card_types or []:
+        keys = card_type.get("key", [])
+        if base_name in keys:
+            return {_base_card_name(name) for name in card_type.get("value", [])}
+    return {base_name}
+
+
+def get_battle_plan_card_candidates(
+        battle_plan: dict,
+        card_types: list[dict] | None,
+) -> set[str]:
+    """获取战斗方案直接写入或经 card type 展开后可能存在的卡名。"""
+    candidates = set()
+    if not isinstance(battle_plan, dict):
+        return candidates
+    for card in battle_plan.get("cards", []):
+        if isinstance(card, dict) and isinstance(card.get("name"), str):
+            candidates.update(_card_name_candidates(card["name"], card_types))
+    return candidates
+
+
 def get_auto_card_target_names(
         stage_mat_card_names: list[str],
         battle_plan_tweak,
+        battle_plan: dict | None = None,
+        card_types: list[dict] | None = None,
 ) -> tuple[list[str], list[str], list[str]]:
     """
     获取本场战斗允许智能识别和使用的辅助卡片名称。
@@ -113,6 +146,8 @@ def get_auto_card_target_names(
     Args:
         stage_mat_card_names: 当前关卡允许使用的承载卡名称。
         battle_plan_tweak: 已加载的微调方案字典。
+        battle_plan: 当前战斗方案。
+        card_types: 卡片类型配置。
 
     Returns:
         三个列表依次为承载卡、冰沙和连携卡的识别目标名称。微调方案关闭
@@ -120,12 +155,29 @@ def get_auto_card_target_names(
     """
     enabled = get_tweak_plan_auto_card_enabled(battle_plan_tweak)
     auto_mat = get_tweak_plan_auto_mat_card(battle_plan_tweak)
-    target_mat_list = copy.deepcopy(stage_mat_card_names) if auto_mat["enabled"] else []
-    target_smoothie_list = ["冰激凌"] if enabled["icecream"] else []
+    existing = get_battle_plan_card_candidates(battle_plan, card_types)
+
+    target_mat_list = []
+    if auto_mat["enabled"]:
+        target_mat_list = [
+            name
+            for name in copy.deepcopy(stage_mat_card_names)
+            if _base_card_name(name) not in existing
+        ]
+
+    smoothie_names = {"冰激凌", "极寒冰沙"}
+    target_smoothie_list = []
+    if enabled["icecream"] and not smoothie_names.intersection(existing):
+        target_smoothie_list = ["冰激凌"]
+
     target_kun_list = []
-    if enabled["ikun"]:
+    if enabled["ikun"] and "幻幻鸡" not in existing:
         target_kun_list.append("幻幻鸡")
-    if enabled["god"]:
+    if (
+            enabled["god"]
+            and "创造神" not in existing
+            and battle_plan_has_creator_god_target(battle_plan)
+    ):
         target_kun_list.append("创造神")
     return target_mat_list, target_smoothie_list, target_kun_list
 
@@ -204,6 +256,7 @@ def get_highest_kun_target(
 def get_auto_timer_target_names(
         battle_plan_tweak: dict,
         battle_plan: dict,
+        card_types: list[dict] | None = None,
 ) -> list[str]:
     """获取本场战斗允许自动携带和使用的美味计时器识别目标。"""
     if not get_tweak_plan_auto_timer_enabled(battle_plan_tweak):
@@ -211,12 +264,8 @@ def get_auto_timer_target_names(
     if get_highest_kun_target(battle_plan) is None:
         return []
 
-    card_names = {
-        card.get("name")
-        for card in battle_plan.get("cards", [])
-        if isinstance(card, dict)
-    }
-    if card_names.intersection({"美味计时器", "冷却辅助", "冷却拐"}):
+    existing = get_battle_plan_card_candidates(battle_plan, card_types)
+    if existing.intersection({"美味计时器", "冷却辅助", "冷却拐"}):
         return []
     return ["美味计时器"]
 

--- a/test/test_auto_card_conflict.py
+++ b/test/test_auto_card_conflict.py
@@ -1,0 +1,105 @@
+import unittest
+from unittest.mock import patch
+
+from function.core.faa.tweak_plan import (
+    get_auto_card_target_names,
+    get_auto_timer_target_names,
+)
+
+
+def make_battle_plan(card_names=None, action_cards=None):
+    card_names = card_names or []
+    action_cards = action_cards or []
+    return {
+        "cards": [
+            {"card_id": index, "name": name}
+            for index, name in enumerate(card_names, start=1)
+        ],
+        "events": [
+            {
+                "trigger": {"type": "wave_timer", "wave_id": 0},
+                "action": {"type": "loop_use_cards", "cards": action_cards},
+            }
+        ],
+    }
+
+
+class AutoCardConflictTest(unittest.TestCase):
+    def setUp(self):
+        self.stage_mat_card_names = ["木盘子", "麦芽糖浆"]
+        self.card_types = [
+            {
+                "key": ["冷却辅助", "冷却拐"],
+                "value": ["时间神", "转龙壶", "美味计时器"],
+            },
+            {
+                "key": ["复制辅助"],
+                "value": ["幻幻鸡", "创造神"],
+            },
+        ]
+        self.safe_kun_action = {
+            "card_id": 1,
+            "location": [
+                f"{column}-{row}"
+                for column in range(2, 5)
+                for row in range(2, 5)
+            ],
+            "kun": 2,
+        }
+
+    def targets(self, card_names):
+        plan = make_battle_plan(card_names, [self.safe_kun_action])
+        auto_targets = get_auto_card_target_names(
+            stage_mat_card_names=self.stage_mat_card_names,
+            battle_plan_tweak={"meta_data": {"enable_auto_card": {"timer": True}}},
+            battle_plan=plan,
+            card_types=self.card_types,
+        )
+        timer_targets = get_auto_timer_target_names(
+            battle_plan_tweak={"meta_data": {"enable_auto_card": {"timer": True}}},
+            battle_plan=plan,
+            card_types=self.card_types,
+        )
+        return (*auto_targets, timer_targets)
+
+    def test_direct_cards_cancel_only_their_automatic_features(self):
+        self.assertEqual(
+            self.targets(["木盘子-3", "极寒冰沙-2", "幻幻鸡", "美味计时器"]),
+            (["麦芽糖浆"], [], ["创造神"], []),
+        )
+
+    def test_card_type_candidates_cancel_copy_and_timer_features(self):
+        self.assertEqual(
+            self.targets(["冷却辅助", "复制辅助"]),
+            (["木盘子", "麦芽糖浆"], ["冰激凌"], [], []),
+        )
+
+    def test_runtime_discovers_all_available_card_stages(self):
+        from PyQt6.QtWidgets import QApplication
+
+        app = QApplication.instance() or QApplication([])
+        from function.core.faa import faa_battle_preparation
+
+        preparation = faa_battle_preparation.BattlePreparation.__new__(
+            faa_battle_preparation.BattlePreparation
+        )
+        preparation.card_types = []
+        resources = {
+            "card": {
+                "准备房间": {
+                    "用户自制卡-0.png": None,
+                    "用户自制卡-2.png": None,
+                    "用户自制卡-4.png": None,
+                }
+            }
+        }
+
+        with patch.object(faa_battle_preparation, "RESOURCE_P", resources):
+            targets = preparation._card_name_to_tar_list("用户自制卡")
+
+        self.assertEqual(targets, ["用户自制卡-4", "用户自制卡-2", "用户自制卡-0"])
+        self.assertIsNotNone(app)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* 战斗方案直接包含承载卡、冰沙、复制卡或美味计时器时，停止额外携带和智能使用同一功能卡。
* 支持展开卡片类型候选项后判断冲突，避免方案使用类型名称时仍重复加入自动卡。
* 自动带卡按准备房间现有图片发现并选择可用阶段，避免固定阶段范围造成错误匹配。
* 自动携带与战斗内识别共用相同目标判定；本 PR 不调整图像资源，现有部分卡片图片仍为占位。