### PR TITLE
fix(自动复制): 仅在当前波次存在有效目标时启用复制卡

### DIFF
--- a/function/core/faa/faa_core.py
+++ b/function/core/faa/faa_core.py
@@ -19,6 +19,7 @@ from function.core.faa.tweak_plan import (
     build_auto_timer_card,
     get_auto_card_target_names,
     get_auto_timer_target_names,
+    get_kun_cards_for_wave,
     get_tweak_plan_mat_card_first,
     insert_mat_cards_by_priority,
 )
@@ -809,6 +810,7 @@ class FAABase:
                 if check_coordinate(card_xy_list, coordinate):
                     kun_cards_info.append({'name': card_name, "card_id": card_id})
         self.kun_cards_info = kun_cards_info
+        self.detected_kun_cards_info = copy.deepcopy(kun_cards_info)
         self.print_info(text="战斗中识图查找连携卡位置, 结果：{}".format(self.kun_cards_info))
 
         timer_info = None
@@ -981,6 +983,15 @@ class FAABase:
 
         def calculation_card_extra(list_cell_all):
 
+            self.kun_cards_info = get_kun_cards_for_wave(
+                detected_kun_cards=getattr(
+                    self,
+                    "detected_kun_cards_info",
+                    self.kun_cards_info,
+                ),
+                cards=list_cell_all,
+            )
+
             timer_card = build_auto_timer_card(timer_info, list_cell_all)
             if timer_card:
                 list_cell_all.append(timer_card)
@@ -1002,18 +1013,6 @@ class FAABase:
                     'queue': False
                 }
                 list_cell_all.append(card_dict)
-
-            if self.kun_cards_info:
-                # 确认卡片在卡组 且 有至少一个kun参数设定
-                kun_already_set = False
-                for card in list_cell_all:
-                    # 遍历已有卡片
-                    if "kun" in card.keys():
-                        kun_already_set = True
-                        break
-                if not kun_already_set:
-                    # 没有设置 那么也视坤位置标记不存在
-                    self.kun_cards_info = []
 
             # 为没有kun参数的方案 默认添加0
             for card in list_cell_all:

--- a/function/core/faa/tweak_plan.py
+++ b/function/core/faa/tweak_plan.py
@@ -156,6 +156,7 @@ def get_auto_card_target_names(
     enabled = get_tweak_plan_auto_card_enabled(battle_plan_tweak)
     auto_mat = get_tweak_plan_auto_mat_card(battle_plan_tweak)
     existing = get_battle_plan_card_candidates(battle_plan, card_types)
+    has_kun_target = get_highest_kun_target(battle_plan) is not None
 
     target_mat_list = []
     if auto_mat["enabled"]:
@@ -171,14 +172,15 @@ def get_auto_card_target_names(
         target_smoothie_list = ["冰激凌"]
 
     target_kun_list = []
-    if enabled["ikun"] and "幻幻鸡" not in existing:
-        target_kun_list.append("幻幻鸡")
-    if (
-            enabled["god"]
-            and "创造神" not in existing
-            and battle_plan_has_creator_god_target(battle_plan)
-    ):
-        target_kun_list.append("创造神")
+    if has_kun_target:
+        if enabled["ikun"] and "幻幻鸡" not in existing:
+            target_kun_list.append("幻幻鸡")
+        if (
+                enabled["god"]
+                and "创造神" not in existing
+                and battle_plan_has_creator_god_target(battle_plan)
+        ):
+            target_kun_list.append("创造神")
     return target_mat_list, target_smoothie_list, target_kun_list
 
 
@@ -227,6 +229,16 @@ def get_highest_kun_target_from_cards(cards: list[dict]) -> dict | None:
             best_card = card
             best_kun = kun
     return best_card
+
+
+def get_kun_cards_for_wave(
+        detected_kun_cards: list[dict] | None,
+        cards: list[dict],
+) -> list[dict]:
+    """仅在当前波次存在正数 ``kun`` 目标时返回已识别的复制卡。"""
+    if get_highest_kun_target_from_cards(cards) is None:
+        return []
+    return copy.deepcopy(detected_kun_cards or [])
 
 
 def get_highest_kun_target(

--- a/test/test_auto_copy_target.py
+++ b/test/test_auto_copy_target.py
@@ -1,0 +1,67 @@
+import unittest
+
+from function.core.faa.tweak_plan import (
+    get_auto_card_target_names,
+    get_kun_cards_for_wave,
+)
+
+
+def make_battle_plan(action_cards):
+    return {
+        "cards": [{"card_id": 1, "name": "测试目标"}],
+        "events": [
+            {
+                "trigger": {"type": "wave_timer", "wave_id": 0},
+                "action": {"type": "loop_use_cards", "cards": action_cards},
+            }
+        ],
+    }
+
+
+class AutoCopyTargetTest(unittest.TestCase):
+    def test_copy_cards_are_not_carried_without_positive_kun_target(self):
+        targets = get_auto_card_target_names(
+            stage_mat_card_names=[],
+            battle_plan_tweak={},
+            battle_plan=make_battle_plan([
+                {"card_id": 1, "location": ["3-3"], "kun": 0},
+            ]),
+            card_types=[],
+        )
+
+        self.assertEqual(targets[2], [])
+
+    def test_positive_kun_target_enables_available_copy_cards(self):
+        targets = get_auto_card_target_names(
+            stage_mat_card_names=[],
+            battle_plan_tweak={},
+            battle_plan=make_battle_plan([
+                {"card_id": 1, "location": ["3-3"], "kun": 1},
+            ]),
+            card_types=[],
+        )
+
+        self.assertEqual(targets[2], ["幻幻鸡"])
+
+    def test_copy_cards_can_be_reenabled_on_a_later_wave(self):
+        detected = [
+            {"name": "幻幻鸡", "card_id": 7},
+            {"name": "创造神", "card_id": 8},
+        ]
+
+        first_wave = get_kun_cards_for_wave(
+            detected,
+            [{"card_id": 1, "location": ["1-1"], "kun": 0}],
+        )
+        later_wave = get_kun_cards_for_wave(
+            detected,
+            [{"card_id": 1, "location": ["1-1"], "kun": 2}],
+        )
+
+        self.assertEqual(first_wave, [])
+        self.assertEqual(later_wave, detected)
+        self.assertIsNot(later_wave, detected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* 战前仅在方案存在正数 `kun` 复制目标时携带并识别幻幻鸡、创造神，避免无目标时占用卡槽。
* 每个波次重新检查当前放卡列表，只在当前波次存在有效复制目标时启用复制卡。
* 保存战前识别到的复制卡信息，修复前一波无目标后续波次仍无法重新启用复制卡的问题。
* 保持创造神完整三乘三安全区域规则不变；本 PR 不调整图像资源，现有部分卡片图片仍为占位。