### PR TITLE
feat(战斗方案编辑器): 提示无法解析的卡片名称

### DIFF
--- a/function/core/qmw_editor_of_battle_plan.py
+++ b/function/core/qmw_editor_of_battle_plan.py
@@ -21,7 +21,7 @@ from function.scattered.class_battle_plan_v3d0 import json_to_obj, TriggerWaveTi
     obj_to_json, Card, MetaData, \
     CardLoopConfig, ActionRandomSingleCard, ActionRandomMultiCard
 from function.widget.MultiLevelMenu import MultiLevelMenu
-from function.widget.CardNameSelector import CardNameSelectorWidget
+from function.widget.CardNameSelector import CardCatalog, CardNameSelectorWidget
 
 double_click_card_list = pyqtSignal(object)
 
@@ -2280,8 +2280,10 @@ class QMWEditorOfBattlePlan(QMainWindow):
         if file_name:
             result = self.load_json(file_path=file_name)
             if result:
+                unresolved_cards = self.find_unresolved_plan_cards()
                 self.init_battle_plan()
                 self.BtnSave.setEnabled(True)
+                self.show_unresolved_card_warning(unresolved_cards)
             else:
                 QMessageBox.critical(
                     self, "JSON文件格式错误",
@@ -2300,6 +2302,32 @@ class QMWEditorOfBattlePlan(QMainWindow):
                     "\n"
                     "可能原因2 - 使用记事本等工具手动进行错误修改, 请删除对应战斗方案重新编写.\n"
                 )
+
+    def find_unresolved_plan_cards(self) -> list[tuple[object, str]]:
+        """返回当前方案中无法由类型配置或准备房间图片解析的原始卡片。"""
+        catalog = CardCatalog()
+        return [
+            (card.card_id, str(card.name))
+            for card in self.battle_plan.cards
+            if catalog.parse(str(card.name)).kind == "unresolved"
+        ]
+
+    def show_unresolved_card_warning(self, unresolved_cards: list[tuple[object, str]]) -> None:
+        """汇总提醒无法解析的卡片，不修改方案内容。"""
+        if not unresolved_cards:
+            return
+
+        card_lines = "\n".join(
+            f"ID {card_id}：{card_name or '（空名称）'}"
+            for card_id, card_name in unresolved_cards
+        )
+        QMessageBox.warning(
+            self,
+            "卡片名称无法解析",
+            "以下卡片名称无法根据卡片类型配置或准备房间图片资源正确解析：\n\n"
+            f"{card_lines}\n\n"
+            "方案仍会正常打开，以上名称不会被自动修改；但自动带卡时可能无法识别这些卡片。",
+        )
 
     def open_json(self):
         """打开窗口 打开json文件"""

--- a/test/card_name_selector_demo/test_model.py
+++ b/test/card_name_selector_demo/test_model.py
@@ -3,6 +3,8 @@
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from PyQt6.QtWidgets import QApplication
 from PyQt6.QtGui import QColor, QFontMetrics, QPalette
@@ -219,6 +221,28 @@ class CardNameSelectorInteractionTest(unittest.TestCase):
         finally:
             if dialog is not None:
                 dialog.close()
+
+    def test_open_plan_warning_reports_unresolved_cards_without_modifying_names(self):
+        from function.core.qmw_editor_of_battle_plan import QMWEditorOfBattlePlan
+
+        cards = [
+            SimpleNamespace(card_id=1, name="海星"),
+            SimpleNamespace(card_id=2, name="炭烧海星-1"),
+            SimpleNamespace(card_id=3, name="无法识别的测试卡"),
+        ]
+        editor = SimpleNamespace(battle_plan=SimpleNamespace(cards=cards))
+
+        unresolved_cards = QMWEditorOfBattlePlan.find_unresolved_plan_cards(editor)
+        self.assertEqual(unresolved_cards, [(3, "无法识别的测试卡")])
+
+        with patch(
+                "function.core.qmw_editor_of_battle_plan.QMessageBox.warning"
+        ) as warning:
+            QMWEditorOfBattlePlan.show_unresolved_card_warning(editor, unresolved_cards)
+
+        warning.assert_called_once()
+        self.assertIn("ID 3：无法识别的测试卡", warning.call_args.args[2])
+        self.assertEqual([card.name for card in cards], ["海星", "炭烧海星-1", "无法识别的测试卡"])
 
     def test_follows_application_palette_change(self):
         original_palette = QPalette(self.app.palette())


### PR DESCRIPTION
* 打开战斗方案时，使用卡片类型配置和准备房间图像资源检查方案中的卡片名称。
* 汇总显示无法解析卡片的 ID 与原始名称，便于用户定位自动带卡可能无法识别的条目。
* 方案仍会正常打开，提示过程不会自动修改或覆盖任何卡片名称。
* 本 PR 不调整图像资源，现有部分图片仍为占位。