### PR TITLE
fix(每日签到): 提高营地钥匙领取稳定性

### DIFF
--- a/function/core/faa/faa_core.py
+++ b/function/core/faa/faa_core.py
@@ -2194,9 +2194,10 @@ class FAABase:
 
             if find:
                 # 领取钥匙
+                time.sleep(0.5)
                 T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=400, y=445)
                 time.sleep(0.5)
-                # 如果还有任务
+                # 如果还有任务奖励也顺手领了
                 for _ in range(10):
                     T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=self.handle, x=175, y=325)
                     time.sleep(0.2)
@@ -3277,7 +3278,7 @@ class FAABase:
                     loop_match_p_in_w(
                         source_handle=self.handle,
                         source_root_handle=self.handle_360,
-                        source_range=[425, 339, 450, 367],
+                        source_range=[420, 339, 450, 365],
                         template=RESOURCE_P["common"]["通用_确定.png"],
                         match_tolerance=0.95,
                         match_interval=0.2,
@@ -3290,7 +3291,7 @@ class FAABase:
                         loop_match_p_in_w(
                             source_handle=self.handle,
                             source_root_handle=self.handle_360,
-                            source_range=[466, 86, 950, 500],
+                            source_range=[420, 339, 450, 365],
                             template=RESOURCE_P["item"]["通用_确定_被选中.png"],
                             match_tolerance=0.95,
                             match_interval=0.2,


### PR DESCRIPTION
* 进入营地领取页面后增加短暂等待，再点击领取钥匙，降低界面尚未稳定时点击失效的概率。
* 领取钥匙后继续尝试点击任务奖励区域，兼顾同页面可领取的额外奖励。
* 顺带收窄物品删除确认按钮及选中态模板的识别区域，减少无关界面内容对确认操作的干扰。
* 本 PR 不调整图像资源，现有部分图片仍为占位。