### PR TITLE
feat(微调方案): 默认启用自动美味计时器

### DIFF
--- a/function/core/faa/tweak_plan.py
+++ b/function/core/faa/tweak_plan.py
@@ -8,7 +8,7 @@ AUTO_CARD_DEFAULTS = {
     "icecream": True,
     "god": True,
     "ikun": True,
-    "timer": False,
+    "timer": True,
 }
 
 # 高练度承载卡可以做到 0 费用，优先铺承载能让后续卡片直接落在有效地形上；

--- a/function/core/qmw_editor_of_tweak_plan.py
+++ b/function/core/qmw_editor_of_tweak_plan.py
@@ -69,7 +69,7 @@ DEFAULT_META_DATA_FALLBACK = {
         "icecream": True,
         "god": True,
         "ikun": True,
-        "timer": False,
+        "timer": True,
     },
 }
 

--- a/resource/template/!默认.json
+++ b/resource/template/!默认.json
@@ -25,7 +25,7 @@
             "icecream": true,
             "god": true,
             "ikun": true,
-            "timer": false
+            "timer": true
         }
     }
 }

--- a/test/test_auto_timer.py
+++ b/test/test_auto_timer.py
@@ -28,12 +28,15 @@ def make_battle_plan(card_names=None, action_cards=None):
 
 
 class AutoTimerTest(unittest.TestCase):
-    def test_timer_is_opt_in_and_requires_positive_kun_target(self):
+    def test_timer_defaults_on_and_requires_positive_kun_target(self):
         battle_plan = make_battle_plan(
             action_cards=[{"kun": 2, "location": ["5-4"]}],
         )
-        self.assertFalse(get_tweak_plan_auto_timer_enabled({"meta_data": {}}))
-        self.assertEqual(get_auto_timer_target_names({"meta_data": {}}, battle_plan), [])
+        self.assertTrue(get_tweak_plan_auto_timer_enabled({"meta_data": {}}))
+        self.assertEqual(
+            get_auto_timer_target_names({"meta_data": {}}, battle_plan),
+            ["美味计时器"],
+        )
 
         tweak = {"meta_data": {"enable_auto_card": {"timer": True}}}
         self.assertEqual(get_auto_timer_target_names(tweak, battle_plan), ["美味计时器"])

--- a/test/test_tweak_plan_schema.py
+++ b/test/test_tweak_plan_schema.py
@@ -99,7 +99,7 @@ class TweakPlanSchemaTest(unittest.TestCase):
             get_tweak_plan_auto_card_enabled(
                 {"meta_data": {"ban_state": {"god": True}}}
             ),
-            {"icecream": True, "god": True, "ikun": True, "timer": False},
+            {"icecream": True, "god": True, "ikun": True, "timer": True},
         )
 
     def test_disabled_auto_cards_produce_no_recognition_targets(self):

--- a/test/tweak_plan_editor_demo/README.md
+++ b/test/tweak_plan_editor_demo/README.md
@@ -84,4 +84,4 @@ uv run python -m unittest test.tweak_plan_editor_demo.test_model test.tweak_plan
 | `enable_auto_card.icecream` | 启用极寒冰沙 | 已接入自动携带与最低优先级使用；方案已包含时不重复加入。 |
 | `enable_auto_card.god` | 启用创造神 | 要求正数 `kun` 目标拥有完整 3×3 安全中心；只越位复制中心格，不推进原卡队列，遍历开启时可复制多个安全中心。 |
 | `enable_auto_card.ikun` | 启用幻幻鸡 | 仅存在正数 `kun` 目标且方案未包含时自动携带、识别和使用。 |
-| `enable_auto_card.timer` | 启用美味计时器 | 默认关闭；放在最高正数 `kun` 目标的首格，循环和遍历均关闭，优先级仅高于自动冰沙；仅二转按 3×1 范围向棋盘内侧偏移。 |
+| `enable_auto_card.timer` | 启用美味计时器 | 默认开启；放在最高正数 `kun` 目标的首格，循环和遍历均关闭，优先级仅高于自动冰沙；仅二转按 3×1 范围向棋盘内侧偏移。 |

--- a/test/tweak_plan_editor_demo/test_appearance.py
+++ b/test/tweak_plan_editor_demo/test_appearance.py
@@ -168,7 +168,7 @@ class TweakPlanAppearanceTest(unittest.TestCase):
         for key, selector in self.window.auto_card_selectors.items():
             self.assertEqual(
                 selector.combo.itemText(0),
-                "缺省 (默认:否)" if key == "timer" else "缺省 (默认:是)",
+                "缺省 (默认:是)",
             )
         self.assertNotIn("coffee", self.window.auto_card_selectors)
         self.assertIn("timer", self.window.auto_card_selectors)

--- a/tweak_plan/!默认.json
+++ b/tweak_plan/!默认.json
@@ -25,7 +25,7 @@
             "icecream": true,
             "god": true,
             "ikun": true,
-            "timer": false
+            "timer": true
         }
     }
 }


### PR DESCRIPTION
* 将运行时与编辑器的美味计时器缺省策略改为启用。
* 同步更新内置微调方案模板和编辑器继承状态说明。
* 更新计时器、方案格式和编辑器外观测试。