### PR TITLE
fix(战利品分析): 修复排序数据保存失败时，仍被判定成功的问题

### DIFF
--- a/function/core/analyzer_of_loot_logs.py
+++ b/function/core/analyzer_of_loot_logs.py
@@ -619,8 +619,7 @@ def update_dag_graph(item_list_new) -> bool:
     if nx.is_directed_acyclic_graph(nx.DiGraph(graph)):
         data['graph'] = graph
         # 保存更新后的 JSON 文件
-        ranking_save_data(json_path=json_path, data=data)
-        return True
+        return ranking_save_data(json_path=json_path, data=data)
     else:
         return False
 
@@ -654,7 +653,8 @@ def find_longest_path_from_dag():
         data["ranking"] = nx.dag_longest_path(G)
         CUS_LOGGER.debug("[有向无环图] [寻找最长链] 成功")
         # 保存更新后的 JSON 文件
-        ranking_save_data(json_path=json_path, data=data)
+        if not ranking_save_data(json_path=json_path, data=data):
+            return None
         return data["ranking"]
 
     except nx.NetworkXError:
@@ -763,8 +763,8 @@ def ranking_save_data(json_path, data):
         json_path: config 中的可写排序文件路径。
         data: 需要保存的 DAG graph 排序数据。
 
-    Raises:
-        Exception: 临时文件写入、落盘或替换失败时抛出, 并尝试清理临时文件。
+    Returns:
+        bool: 保存成功时返回 True; 失败时记录错误、清理临时文件并返回 False。
     """
     # 自旋锁读写, 防止多线程读写问题
     with EXTRA.FILE_LOCK:
@@ -782,4 +782,6 @@ def ranking_save_data(json_path, data):
                     os.remove(temp_path)
                 except OSError:
                     pass
-            raise
+            return False
+
+        return True

--- a/test/test_ranking_data_io.py
+++ b/test/test_ranking_data_io.py
@@ -1,0 +1,66 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication
+
+QT_APP = QApplication.instance() or QApplication([])
+
+from function.core import analyzer_of_loot_logs
+
+
+class TestRankingDataIo(unittest.TestCase):
+    def test_save_failure_returns_false_and_removes_temp_file(self):
+        with tempfile.TemporaryDirectory(dir="test") as temp_dir:
+            json_path = os.path.join(temp_dir, "ranking.json")
+            with (
+                    patch.object(analyzer_of_loot_logs.os, "replace", side_effect=PermissionError(5, "拒绝访问")),
+                    patch.object(analyzer_of_loot_logs.CUS_LOGGER, "error") as error_log,
+            ):
+                result = analyzer_of_loot_logs.ranking_save_data(
+                    json_path=json_path,
+                    data={"ranking": [], "graph": {}},
+                )
+
+            self.assertFalse(result)
+            self.assertEqual(os.listdir(temp_dir), [])
+            error_log.assert_called_once()
+
+    def test_save_success_returns_true(self):
+        with tempfile.TemporaryDirectory(dir="test") as temp_dir:
+            json_path = os.path.join(temp_dir, "ranking.json")
+            data = {"ranking": ["A"], "graph": {"A": []}}
+
+            result = analyzer_of_loot_logs.ranking_save_data(json_path=json_path, data=data)
+
+            self.assertTrue(result)
+            with open(json_path, mode="r", encoding="utf-8") as file:
+                self.assertEqual(json.load(file), data)
+
+    def test_update_graph_skips_record_when_save_fails(self):
+        data = {"ranking": [], "graph": {}}
+        with (
+                patch.object(analyzer_of_loot_logs, "ranking_read_data", return_value=data),
+                patch.object(analyzer_of_loot_logs, "ranking_save_data", return_value=False),
+        ):
+            result = analyzer_of_loot_logs.update_dag_graph(["A", "B"])
+
+        self.assertFalse(result)
+
+    def test_longest_path_returns_none_when_save_fails(self):
+        data = {"ranking": [], "graph": {"A": ["B"], "B": []}}
+        with (
+                patch.object(analyzer_of_loot_logs, "ranking_read_data", return_value=data),
+                patch.object(analyzer_of_loot_logs, "ranking_save_data", return_value=False),
+        ):
+            result = analyzer_of_loot_logs.find_longest_path_from_dag()
+
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* 排序数据写入或替换失败时返回失败结果，并清理临时文件。
* DAG 更新和最长链计算会正确传播保存失败，不再继续记录为成功。
* 补充保存成功、保存失败及上游调用传播的回归测试。