### PR TITLE
fix: 修复背包过大导致自动选卡复位不成功

### DIFF
--- a/function/core/faa/faa_battle_preparation.py
+++ b/function/core/faa/faa_battle_preparation.py
@@ -349,6 +349,9 @@ class BattlePreparation:
             # 复位滑块
             T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=handle, x=931, y=209)
             time.sleep(0.5)
+            #再点一下箭头确保一定复位到顶端，否则第一行卡片只有半截无法识别
+            T_ACTION_QUEUE_TIMER.add_click_to_queue(handle=handle, x=931, y=187)
+            time.sleep(0.5)
 
             for i in range(21):
                 if tar_page_num is None or i >= tar_page_num:


### PR DESCRIPTION
随着75格背包的普及，原有的背包复位顶部已经无法成功复位到背包顶部，由此衍生大量的问题，如：第一行卡片无法检测到，复位不正确导致向下翻时产生一定错位导致图片哈希不正确导致明明有卡依然认定为无卡（大量出现缺卡，实则都有）

已实机验证修复